### PR TITLE
Fix aggressive-loop-optimizations warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SRC_DIR  = ./src
 UTIL_DIR = ./utils
 
 
-CFLAGS   := -O3 $(CFLAGS) -std=c11 -Wall -Wextra -Wpedantic -Werror -fno-omit-frame-pointer -Wno-aggressive-loop-optimizations -Wno-unknown-warning-option #-pg -g
+CFLAGS   := -O3 $(CFLAGS) -std=c11 -Wall -Wextra -Wpedantic -Werror -fno-omit-frame-pointer #-pg -g
 CXXFLAGS := -O3 $(CPPFLAGS) -Wall -Wextra -fno-exceptions -fno-rtti -nostdinc++
 INCPATH  := -I/usr/local/include -I/opt/local/include -I/usr/include -I$(SRC_DIR) -I$(UTIL_DIR) -Iunit_tests -Ibenchmark
 LIBPATH  = -L/usr/local/lib -L/opt/local/lib -L/usr/lib

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SRC_DIR  = ./src
 UTIL_DIR = ./utils
 
 
-CFLAGS   := -O3 $(CFLAGS) -std=c11 -Wall -Wextra -Wpedantic -Werror -fno-omit-frame-pointer #-pg -g
+CFLAGS   := -O3 $(CFLAGS) -std=c11 -Wall -Wextra -Wpedantic -Werror -fno-omit-frame-pointer
 CXXFLAGS := -O3 $(CPPFLAGS) -Wall -Wextra -fno-exceptions -fno-rtti -nostdinc++
 INCPATH  := -I/usr/local/include -I/opt/local/include -I/usr/include -I$(SRC_DIR) -I$(UTIL_DIR) -Iunit_tests -Ibenchmark
 LIBPATH  = -L/usr/local/lib -L/opt/local/lib -L/usr/lib

--- a/src/ov_publicmap.c
+++ b/src/ov_publicmap.c
@@ -186,13 +186,14 @@ void madd_reduce_gf16( unsigned char *y, const unsigned char *tmp_res, unsigned 
 
 
 static
-void accu_eval_quad_gf256( unsigned char *accu_low, unsigned char *accu_high, const unsigned char *trimat, const unsigned char *x_in_byte,
-                           unsigned num_gfele_x, unsigned num_vinegar, unsigned vec_len ) {
+void accu_eval_quad_gf256( unsigned char *accu_low, unsigned char *accu_high, const unsigned char *trimat, const unsigned char *x_in_byte) {
+    unsigned vec_len = _PUB_M_BYTE;
+
     const unsigned char *_x = x_in_byte;
     unsigned char _xixj[_MAX_N];
-    unsigned v = num_vinegar;
-    unsigned o = num_gfele_x - num_vinegar;
-    unsigned n = num_gfele_x;
+    unsigned v = _V;
+    unsigned o = _PUB_N - _V;
+    unsigned n = _PUB_N;
 
     #if defined( _BLAS_AVX2_ )
     unsigned tmpvec_len = ((vec_len + 31) >> 5) << 5;
@@ -345,13 +346,14 @@ void accu_eval_quad_gf256( unsigned char *accu_low, unsigned char *accu_high, co
 #else
 
 static
-void accu_eval_quad_gf256( unsigned char *accu_low, unsigned char *accu_high, const unsigned char *trimat, const unsigned char *x_in_byte,
-                           unsigned num_gfele_x, unsigned num_vinegar, unsigned vec_len ) {
+void accu_eval_quad_gf256( unsigned char *accu_low, unsigned char *accu_high, const unsigned char *trimat, const unsigned char *x_in_byte) {
+    unsigned vec_len = _PUB_M_BYTE;
+
     const unsigned char *_x = x_in_byte;
     unsigned char _xixj[_MAX_N];
-    unsigned v = num_vinegar;
-    unsigned o = num_gfele_x - num_vinegar;
-    unsigned n = num_gfele_x;
+    unsigned v = _V;
+    unsigned o = _PUB_N - _V;
+    unsigned n = _PUB_N;
 
     #if defined( _BLAS_AVX2_ )
     unsigned tmpvec_len = ((vec_len + 31) >> 5) << 5;
@@ -563,7 +565,8 @@ void ov_publicmap( unsigned char *y, const unsigned char *trimat, const unsigned
 
     unsigned char tmp_l[TMPVEC_LEN * 16] = {0};
     unsigned char tmp_h[TMPVEC_LEN * 16] = {0};
-    accu_eval_quad_gf256( tmp_l, tmp_h, trimat, _x, _PUB_N, _V, _PUB_M_BYTE );
+    // accu_eval_quad_gf256( tmp_l, tmp_h, trimat, _x, _PUB_N, _V, _PUB_M_BYTE );
+    accu_eval_quad_gf256( tmp_l, tmp_h, trimat, _x );
     madd_reduce_gf256( y, tmp_l, tmp_h, _PUB_M_BYTE );
 
     #else

--- a/src/ov_publicmap.c
+++ b/src/ov_publicmap.c
@@ -565,7 +565,6 @@ void ov_publicmap( unsigned char *y, const unsigned char *trimat, const unsigned
 
     unsigned char tmp_l[TMPVEC_LEN * 16] = {0};
     unsigned char tmp_h[TMPVEC_LEN * 16] = {0};
-    // accu_eval_quad_gf256( tmp_l, tmp_h, trimat, _x, _PUB_N, _V, _PUB_M_BYTE );
     accu_eval_quad_gf256( tmp_l, tmp_h, trimat, _x );
     madd_reduce_gf256( y, tmp_l, tmp_h, _PUB_M_BYTE );
 


### PR DESCRIPTION
For some reason gcc issued the following warning:
```
gcc -O3  -std=c11 -Wall -Wextra -Wpedantic -Werror -fno-omit-frame-pointer  -D_OV256_112_44 -D_OV_CLASSIC -I/usr/local/include -I/opt/local/include -I/usr/include -I./src -I./utils -Iunit_tests -Ibenchmark -I./src/ref -c src/ov_publicmap.c
src/ov_publicmap.c: In function ‘accu_eval_quad_gf256.constprop’:
src/ov_publicmap.c:314:33: error: iteration 2[12](https://github.com/pqov/pqov/actions/runs/4249097033/jobs/7388926688#step:3:13) invokes undefined behavior [-Werror=aggressive-loop-optimizations]
  314 |             unsigned idx = _xixj[j];
      |                            ~~~~~^~~
src/ov_publicmap.c:3[13](https://github.com/pqov/pqov/actions/runs/4249097033/jobs/7388926688#step:3:14):18: note: within this loop
  313 |         for (; j < o; j++) {
      |                ~~^~~
cc1: all warnings being treated as errors
```
See, e.g., https://github.com/pqov/pqov/actions/runs/4240849376/jobs/7370339686

Removing the function arguments that are constant anyway, resolves the issue.

Resolves #4 