### PR TITLE
Fix MacOS build + Disable MacOS CI

### DIFF
--- a/.github/workflows/generate.py
+++ b/.github/workflows/generate.py
@@ -67,40 +67,42 @@ jobs:
           - gcc-12
         impl: # there is no AVX2 available on the MacOS runners
           - ref
-          - ssse3
-          - amd64
+          - neon
     runs-on: macos-latest
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Setup openssl
+      run: | 
+        brew install openssl
     - uses: actions/checkout@v3
     - name: Set up compiler
       run: |
         export CC=${{ matrix.cc }}
-        sysctl -a machdep.cpu
+        sysctl -a machdep.cpu  
     - name: test
       run: make PARAM=$PARAM VARIANT=$VARIANT PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
     - name: asan
       run: |
         make clean
         make ASAN=1 PARAM=$PARAM VARIANT=$VARIANT PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
     - name: ubsan
       run: |
         make clean
         make UBSAN=1 PARAM=$PARAM VARIANT=$VARIANT PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
 """
 
 
@@ -108,9 +110,9 @@ workflow_nistkat = """name: NISTKAT $NAME
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
 
 jobs:
   test-ubuntu:
@@ -148,6 +150,9 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Setup openssl
+      run: | 
+        brew install openssl
     - uses: actions/checkout@v3
     - name: Set up compiler
       run: 'export CC=${{ matrix.cc }}'
@@ -157,8 +162,8 @@ jobs:
         make KAT=1 PARAM=$PARAM VARIANT=$VARIANT PROJ=${{ matrix.impl }} check-NISTKAT
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
 """
 
 def paramToName(p):

--- a/.github/workflows/generate.py
+++ b/.github/workflows/generate.py
@@ -58,51 +58,52 @@ jobs:
       run: |
         make VALGRIND=1 PARAM=$PARAM VARIANT=$VARIANT PROJ=${{ matrix.impl }} sign_api-test
         valgrind --error-exitcode=1 --exit-on-first-error=yes --leak-check=yes ./sign_api-test
-  test-macos:
-    name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
-    strategy:
-      matrix:
-        cc:
-          - clang
-          - gcc-12
-        impl: # there is no AVX2 available on the MacOS runners
-          - ref
-          - neon
-    runs-on: macos-latest
-    steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Setup openssl
-      run: | 
-        brew install openssl
-    - uses: actions/checkout@v3
-    - name: Set up compiler
-      run: |
-        export CC=${{ matrix.cc }}
-        sysctl -a machdep.cpu  
-    - name: test
-      run: make PARAM=$PARAM VARIANT=$VARIANT PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
-    - name: asan
-      run: |
-        make clean
-        make ASAN=1 PARAM=$PARAM VARIANT=$VARIANT PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
-    - name: ubsan
-      run: |
-        make clean
-        make UBSAN=1 PARAM=$PARAM VARIANT=$VARIANT PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  # TODO: fix this in the Github CI
+  #test-macos:
+  #  name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
+  #  strategy:
+  #    matrix:
+  #      cc:
+  #        - clang
+  #        - gcc-12
+  #      impl: # there is no AVX2 available on the MacOS runners
+  #        - ref
+  #        - neon
+  #  runs-on: macos-latest
+  #  steps:
+  #  - uses: maxim-lobanov/setup-xcode@v1
+  #    with:
+  #      xcode-version: latest-stable
+  #  - name: Setup openssl
+  #    run: | 
+  #      brew install openssl
+  #  - uses: actions/checkout@v3
+  #  - name: Set up compiler
+  #    run: |
+  #      export CC=${{ matrix.cc }}
+  #      sysctl -a machdep.cpu  
+  #  - name: test
+  #    run: make PARAM=$PARAM VARIANT=$VARIANT PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  #  - name: asan
+  #    run: |
+  #      make clean
+  #      make ASAN=1 PARAM=$PARAM VARIANT=$VARIANT PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  #  - name: ubsan
+  #    run: |
+  #      make clean
+  #      make UBSAN=1 PARAM=$PARAM VARIANT=$VARIANT PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
 """
 
 
@@ -134,35 +135,36 @@ jobs:
       run: make KAT=1 PARAM=$PARAM VARIANT=$VARIANT PROJ=${{ matrix.impl }} check-NISTKAT
       env:
         CC: ${{ matrix.cc }}
-  test-macos:
-    name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
-    strategy:
-      matrix:
-        cc:
-          - clang
-          - gcc-12
-        impl:
-          - ref
-          - neon
-    runs-on: macos-latest
-    steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Setup openssl
-      run: | 
-        brew install openssl
-    - uses: actions/checkout@v3
-    - name: Set up compiler
-      run: 'export CC=${{ matrix.cc }}'
-    - name: test
-      run: |
-        function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
-        make KAT=1 PARAM=$PARAM VARIANT=$VARIANT PROJ=${{ matrix.impl }} check-NISTKAT
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  # TODO: fix this in the Github CI
+  #test-macos:
+  #  name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
+  #  strategy:
+  #    matrix:
+  #      cc:
+  #        - clang
+  #        - gcc-12
+  #      impl:
+  #        - ref
+  #        - neon
+  #  runs-on: macos-latest
+  #  steps:
+  #  - uses: maxim-lobanov/setup-xcode@v1
+  #    with:
+  #      xcode-version: latest-stable
+  #  - name: Setup openssl
+  #    run: | 
+  #      brew install openssl
+  #  - uses: actions/checkout@v3
+  #  - name: Set up compiler
+  #    run: 'export CC=${{ matrix.cc }}'
+  #  - name: test
+  #    run: |
+  #      function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
+  #      make KAT=1 PARAM=$PARAM VARIANT=$VARIANT PROJ=${{ matrix.impl }} check-NISTKAT
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
 """
 
 def paramToName(p):

--- a/.github/workflows/generate.py
+++ b/.github/workflows/generate.py
@@ -4,9 +4,9 @@ workflow_test = """name: Test $NAME
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
 
 jobs:
   test:
@@ -143,8 +143,7 @@ jobs:
           - gcc-12
         impl:
           - ref
-          - ssse3
-          - amd64
+          - neon
     runs-on: macos-latest
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/nistkat_OV16_160_64_classic.yml
+++ b/.github/workflows/nistkat_OV16_160_64_classic.yml
@@ -35,8 +35,7 @@ jobs:
           - gcc-12
         impl:
           - ref
-          - ssse3
-          - amd64
+          - neon
     runs-on: macos-latest
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/nistkat_OV16_160_64_classic.yml
+++ b/.github/workflows/nistkat_OV16_160_64_classic.yml
@@ -2,9 +2,9 @@ name: NISTKAT OV16_160_64_classic
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
 
 jobs:
   test-ubuntu:
@@ -42,6 +42,9 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Setup openssl
+      run: | 
+        brew install openssl
     - uses: actions/checkout@v3
     - name: Set up compiler
       run: 'export CC=${{ matrix.cc }}'
@@ -51,5 +54,5 @@ jobs:
         make KAT=1 PARAM=1 VARIANT=1 PROJ=${{ matrix.impl }} check-NISTKAT
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/nistkat_OV16_160_64_classic.yml
+++ b/.github/workflows/nistkat_OV16_160_64_classic.yml
@@ -26,32 +26,33 @@ jobs:
       run: make KAT=1 PARAM=1 VARIANT=1 PROJ=${{ matrix.impl }} check-NISTKAT
       env:
         CC: ${{ matrix.cc }}
-  test-macos:
-    name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
-    strategy:
-      matrix:
-        cc:
-          - clang
-          - gcc-12
-        impl:
-          - ref
-          - neon
-    runs-on: macos-latest
-    steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Setup openssl
-      run: | 
-        brew install openssl
-    - uses: actions/checkout@v3
-    - name: Set up compiler
-      run: 'export CC=${{ matrix.cc }}'
-    - name: test
-      run: |
-        function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
-        make KAT=1 PARAM=1 VARIANT=1 PROJ=${{ matrix.impl }} check-NISTKAT
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  # TODO: fix this in the Github CI
+  #test-macos:
+  #  name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
+  #  strategy:
+  #    matrix:
+  #      cc:
+  #        - clang
+  #        - gcc-12
+  #      impl:
+  #        - ref
+  #        - neon
+  #  runs-on: macos-latest
+  #  steps:
+  #  - uses: maxim-lobanov/setup-xcode@v1
+  #    with:
+  #      xcode-version: latest-stable
+  #  - name: Setup openssl
+  #    run: | 
+  #      brew install openssl
+  #  - uses: actions/checkout@v3
+  #  - name: Set up compiler
+  #    run: 'export CC=${{ matrix.cc }}'
+  #  - name: test
+  #    run: |
+  #      function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
+  #      make KAT=1 PARAM=1 VARIANT=1 PROJ=${{ matrix.impl }} check-NISTKAT
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/nistkat_OV16_160_64_pkc.yml
+++ b/.github/workflows/nistkat_OV16_160_64_pkc.yml
@@ -26,32 +26,33 @@ jobs:
       run: make KAT=1 PARAM=1 VARIANT=2 PROJ=${{ matrix.impl }} check-NISTKAT
       env:
         CC: ${{ matrix.cc }}
-  test-macos:
-    name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
-    strategy:
-      matrix:
-        cc:
-          - clang
-          - gcc-12
-        impl:
-          - ref
-          - neon
-    runs-on: macos-latest
-    steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Setup openssl
-      run: | 
-        brew install openssl
-    - uses: actions/checkout@v3
-    - name: Set up compiler
-      run: 'export CC=${{ matrix.cc }}'
-    - name: test
-      run: |
-        function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
-        make KAT=1 PARAM=1 VARIANT=2 PROJ=${{ matrix.impl }} check-NISTKAT
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  # TODO: fix this in the Github CI
+  #test-macos:
+  #  name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
+  #  strategy:
+  #    matrix:
+  #      cc:
+  #        - clang
+  #        - gcc-12
+  #      impl:
+  #        - ref
+  #        - neon
+  #  runs-on: macos-latest
+  #  steps:
+  #  - uses: maxim-lobanov/setup-xcode@v1
+  #    with:
+  #      xcode-version: latest-stable
+  #  - name: Setup openssl
+  #    run: | 
+  #      brew install openssl
+  #  - uses: actions/checkout@v3
+  #  - name: Set up compiler
+  #    run: 'export CC=${{ matrix.cc }}'
+  #  - name: test
+  #    run: |
+  #      function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
+  #      make KAT=1 PARAM=1 VARIANT=2 PROJ=${{ matrix.impl }} check-NISTKAT
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/nistkat_OV16_160_64_pkc.yml
+++ b/.github/workflows/nistkat_OV16_160_64_pkc.yml
@@ -2,9 +2,9 @@ name: NISTKAT OV16_160_64_pkc
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
 
 jobs:
   test-ubuntu:
@@ -42,6 +42,9 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Setup openssl
+      run: | 
+        brew install openssl
     - uses: actions/checkout@v3
     - name: Set up compiler
       run: 'export CC=${{ matrix.cc }}'
@@ -51,5 +54,5 @@ jobs:
         make KAT=1 PARAM=1 VARIANT=2 PROJ=${{ matrix.impl }} check-NISTKAT
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/nistkat_OV16_160_64_pkc.yml
+++ b/.github/workflows/nistkat_OV16_160_64_pkc.yml
@@ -35,8 +35,7 @@ jobs:
           - gcc-12
         impl:
           - ref
-          - ssse3
-          - amd64
+          - neon
     runs-on: macos-latest
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/nistkat_OV16_160_64_pkc_skc.yml
+++ b/.github/workflows/nistkat_OV16_160_64_pkc_skc.yml
@@ -26,32 +26,33 @@ jobs:
       run: make KAT=1 PARAM=1 VARIANT=3 PROJ=${{ matrix.impl }} check-NISTKAT
       env:
         CC: ${{ matrix.cc }}
-  test-macos:
-    name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
-    strategy:
-      matrix:
-        cc:
-          - clang
-          - gcc-12
-        impl:
-          - ref
-          - neon
-    runs-on: macos-latest
-    steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Setup openssl
-      run: | 
-        brew install openssl
-    - uses: actions/checkout@v3
-    - name: Set up compiler
-      run: 'export CC=${{ matrix.cc }}'
-    - name: test
-      run: |
-        function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
-        make KAT=1 PARAM=1 VARIANT=3 PROJ=${{ matrix.impl }} check-NISTKAT
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  # TODO: fix this in the Github CI
+  #test-macos:
+  #  name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
+  #  strategy:
+  #    matrix:
+  #      cc:
+  #        - clang
+  #        - gcc-12
+  #      impl:
+  #        - ref
+  #        - neon
+  #  runs-on: macos-latest
+  #  steps:
+  #  - uses: maxim-lobanov/setup-xcode@v1
+  #    with:
+  #      xcode-version: latest-stable
+  #  - name: Setup openssl
+  #    run: | 
+  #      brew install openssl
+  #  - uses: actions/checkout@v3
+  #  - name: Set up compiler
+  #    run: 'export CC=${{ matrix.cc }}'
+  #  - name: test
+  #    run: |
+  #      function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
+  #      make KAT=1 PARAM=1 VARIANT=3 PROJ=${{ matrix.impl }} check-NISTKAT
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/nistkat_OV16_160_64_pkc_skc.yml
+++ b/.github/workflows/nistkat_OV16_160_64_pkc_skc.yml
@@ -35,8 +35,7 @@ jobs:
           - gcc-12
         impl:
           - ref
-          - ssse3
-          - amd64
+          - neon
     runs-on: macos-latest
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/nistkat_OV16_160_64_pkc_skc.yml
+++ b/.github/workflows/nistkat_OV16_160_64_pkc_skc.yml
@@ -2,9 +2,9 @@ name: NISTKAT OV16_160_64_pkc_skc
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
 
 jobs:
   test-ubuntu:
@@ -42,6 +42,9 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Setup openssl
+      run: | 
+        brew install openssl
     - uses: actions/checkout@v3
     - name: Set up compiler
       run: 'export CC=${{ matrix.cc }}'
@@ -51,5 +54,5 @@ jobs:
         make KAT=1 PARAM=1 VARIANT=3 PROJ=${{ matrix.impl }} check-NISTKAT
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/nistkat_OV256_112_44_classic.yml
+++ b/.github/workflows/nistkat_OV256_112_44_classic.yml
@@ -2,9 +2,9 @@ name: NISTKAT OV256_112_44_classic
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
 
 jobs:
   test-ubuntu:
@@ -42,6 +42,9 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Setup openssl
+      run: | 
+        brew install openssl
     - uses: actions/checkout@v3
     - name: Set up compiler
       run: 'export CC=${{ matrix.cc }}'
@@ -51,5 +54,5 @@ jobs:
         make KAT=1 PARAM=3 VARIANT=1 PROJ=${{ matrix.impl }} check-NISTKAT
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/nistkat_OV256_112_44_classic.yml
+++ b/.github/workflows/nistkat_OV256_112_44_classic.yml
@@ -26,32 +26,33 @@ jobs:
       run: make KAT=1 PARAM=3 VARIANT=1 PROJ=${{ matrix.impl }} check-NISTKAT
       env:
         CC: ${{ matrix.cc }}
-  test-macos:
-    name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
-    strategy:
-      matrix:
-        cc:
-          - clang
-          - gcc-12
-        impl:
-          - ref
-          - neon
-    runs-on: macos-latest
-    steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Setup openssl
-      run: | 
-        brew install openssl
-    - uses: actions/checkout@v3
-    - name: Set up compiler
-      run: 'export CC=${{ matrix.cc }}'
-    - name: test
-      run: |
-        function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
-        make KAT=1 PARAM=3 VARIANT=1 PROJ=${{ matrix.impl }} check-NISTKAT
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  # TODO: fix this in the Github CI
+  #test-macos:
+  #  name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
+  #  strategy:
+  #    matrix:
+  #      cc:
+  #        - clang
+  #        - gcc-12
+  #      impl:
+  #        - ref
+  #        - neon
+  #  runs-on: macos-latest
+  #  steps:
+  #  - uses: maxim-lobanov/setup-xcode@v1
+  #    with:
+  #      xcode-version: latest-stable
+  #  - name: Setup openssl
+  #    run: | 
+  #      brew install openssl
+  #  - uses: actions/checkout@v3
+  #  - name: Set up compiler
+  #    run: 'export CC=${{ matrix.cc }}'
+  #  - name: test
+  #    run: |
+  #      function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
+  #      make KAT=1 PARAM=3 VARIANT=1 PROJ=${{ matrix.impl }} check-NISTKAT
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/nistkat_OV256_112_44_classic.yml
+++ b/.github/workflows/nistkat_OV256_112_44_classic.yml
@@ -35,8 +35,7 @@ jobs:
           - gcc-12
         impl:
           - ref
-          - ssse3
-          - amd64
+          - neon
     runs-on: macos-latest
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/nistkat_OV256_112_44_pkc.yml
+++ b/.github/workflows/nistkat_OV256_112_44_pkc.yml
@@ -2,9 +2,9 @@ name: NISTKAT OV256_112_44_pkc
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
 
 jobs:
   test-ubuntu:
@@ -42,6 +42,9 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Setup openssl
+      run: | 
+        brew install openssl
     - uses: actions/checkout@v3
     - name: Set up compiler
       run: 'export CC=${{ matrix.cc }}'
@@ -51,5 +54,5 @@ jobs:
         make KAT=1 PARAM=3 VARIANT=2 PROJ=${{ matrix.impl }} check-NISTKAT
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/nistkat_OV256_112_44_pkc.yml
+++ b/.github/workflows/nistkat_OV256_112_44_pkc.yml
@@ -26,32 +26,33 @@ jobs:
       run: make KAT=1 PARAM=3 VARIANT=2 PROJ=${{ matrix.impl }} check-NISTKAT
       env:
         CC: ${{ matrix.cc }}
-  test-macos:
-    name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
-    strategy:
-      matrix:
-        cc:
-          - clang
-          - gcc-12
-        impl:
-          - ref
-          - neon
-    runs-on: macos-latest
-    steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Setup openssl
-      run: | 
-        brew install openssl
-    - uses: actions/checkout@v3
-    - name: Set up compiler
-      run: 'export CC=${{ matrix.cc }}'
-    - name: test
-      run: |
-        function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
-        make KAT=1 PARAM=3 VARIANT=2 PROJ=${{ matrix.impl }} check-NISTKAT
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  # TODO: fix this in the Github CI
+  #test-macos:
+  #  name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
+  #  strategy:
+  #    matrix:
+  #      cc:
+  #        - clang
+  #        - gcc-12
+  #      impl:
+  #        - ref
+  #        - neon
+  #  runs-on: macos-latest
+  #  steps:
+  #  - uses: maxim-lobanov/setup-xcode@v1
+  #    with:
+  #      xcode-version: latest-stable
+  #  - name: Setup openssl
+  #    run: | 
+  #      brew install openssl
+  #  - uses: actions/checkout@v3
+  #  - name: Set up compiler
+  #    run: 'export CC=${{ matrix.cc }}'
+  #  - name: test
+  #    run: |
+  #      function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
+  #      make KAT=1 PARAM=3 VARIANT=2 PROJ=${{ matrix.impl }} check-NISTKAT
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/nistkat_OV256_112_44_pkc.yml
+++ b/.github/workflows/nistkat_OV256_112_44_pkc.yml
@@ -35,8 +35,7 @@ jobs:
           - gcc-12
         impl:
           - ref
-          - ssse3
-          - amd64
+          - neon
     runs-on: macos-latest
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/nistkat_OV256_112_44_pkc_skc.yml
+++ b/.github/workflows/nistkat_OV256_112_44_pkc_skc.yml
@@ -2,9 +2,9 @@ name: NISTKAT OV256_112_44_pkc_skc
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
 
 jobs:
   test-ubuntu:
@@ -42,6 +42,9 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Setup openssl
+      run: | 
+        brew install openssl
     - uses: actions/checkout@v3
     - name: Set up compiler
       run: 'export CC=${{ matrix.cc }}'
@@ -51,5 +54,5 @@ jobs:
         make KAT=1 PARAM=3 VARIANT=3 PROJ=${{ matrix.impl }} check-NISTKAT
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/nistkat_OV256_112_44_pkc_skc.yml
+++ b/.github/workflows/nistkat_OV256_112_44_pkc_skc.yml
@@ -26,32 +26,33 @@ jobs:
       run: make KAT=1 PARAM=3 VARIANT=3 PROJ=${{ matrix.impl }} check-NISTKAT
       env:
         CC: ${{ matrix.cc }}
-  test-macos:
-    name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
-    strategy:
-      matrix:
-        cc:
-          - clang
-          - gcc-12
-        impl:
-          - ref
-          - neon
-    runs-on: macos-latest
-    steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Setup openssl
-      run: | 
-        brew install openssl
-    - uses: actions/checkout@v3
-    - name: Set up compiler
-      run: 'export CC=${{ matrix.cc }}'
-    - name: test
-      run: |
-        function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
-        make KAT=1 PARAM=3 VARIANT=3 PROJ=${{ matrix.impl }} check-NISTKAT
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  # TODO: fix this in the Github CI
+  #test-macos:
+  #  name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
+  #  strategy:
+  #    matrix:
+  #      cc:
+  #        - clang
+  #        - gcc-12
+  #      impl:
+  #        - ref
+  #        - neon
+  #  runs-on: macos-latest
+  #  steps:
+  #  - uses: maxim-lobanov/setup-xcode@v1
+  #    with:
+  #      xcode-version: latest-stable
+  #  - name: Setup openssl
+  #    run: | 
+  #      brew install openssl
+  #  - uses: actions/checkout@v3
+  #  - name: Set up compiler
+  #    run: 'export CC=${{ matrix.cc }}'
+  #  - name: test
+  #    run: |
+  #      function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
+  #      make KAT=1 PARAM=3 VARIANT=3 PROJ=${{ matrix.impl }} check-NISTKAT
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/nistkat_OV256_112_44_pkc_skc.yml
+++ b/.github/workflows/nistkat_OV256_112_44_pkc_skc.yml
@@ -35,8 +35,7 @@ jobs:
           - gcc-12
         impl:
           - ref
-          - ssse3
-          - amd64
+          - neon
     runs-on: macos-latest
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/nistkat_OV256_184_72_classic.yml
+++ b/.github/workflows/nistkat_OV256_184_72_classic.yml
@@ -2,9 +2,9 @@ name: NISTKAT OV256_184_72_classic
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
 
 jobs:
   test-ubuntu:
@@ -42,6 +42,9 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Setup openssl
+      run: | 
+        brew install openssl
     - uses: actions/checkout@v3
     - name: Set up compiler
       run: 'export CC=${{ matrix.cc }}'
@@ -51,5 +54,5 @@ jobs:
         make KAT=1 PARAM=4 VARIANT=1 PROJ=${{ matrix.impl }} check-NISTKAT
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/nistkat_OV256_184_72_classic.yml
+++ b/.github/workflows/nistkat_OV256_184_72_classic.yml
@@ -26,32 +26,33 @@ jobs:
       run: make KAT=1 PARAM=4 VARIANT=1 PROJ=${{ matrix.impl }} check-NISTKAT
       env:
         CC: ${{ matrix.cc }}
-  test-macos:
-    name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
-    strategy:
-      matrix:
-        cc:
-          - clang
-          - gcc-12
-        impl:
-          - ref
-          - neon
-    runs-on: macos-latest
-    steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Setup openssl
-      run: | 
-        brew install openssl
-    - uses: actions/checkout@v3
-    - name: Set up compiler
-      run: 'export CC=${{ matrix.cc }}'
-    - name: test
-      run: |
-        function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
-        make KAT=1 PARAM=4 VARIANT=1 PROJ=${{ matrix.impl }} check-NISTKAT
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  # TODO: fix this in the Github CI
+  #test-macos:
+  #  name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
+  #  strategy:
+  #    matrix:
+  #      cc:
+  #        - clang
+  #        - gcc-12
+  #      impl:
+  #        - ref
+  #        - neon
+  #  runs-on: macos-latest
+  #  steps:
+  #  - uses: maxim-lobanov/setup-xcode@v1
+  #    with:
+  #      xcode-version: latest-stable
+  #  - name: Setup openssl
+  #    run: | 
+  #      brew install openssl
+  #  - uses: actions/checkout@v3
+  #  - name: Set up compiler
+  #    run: 'export CC=${{ matrix.cc }}'
+  #  - name: test
+  #    run: |
+  #      function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
+  #      make KAT=1 PARAM=4 VARIANT=1 PROJ=${{ matrix.impl }} check-NISTKAT
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/nistkat_OV256_184_72_classic.yml
+++ b/.github/workflows/nistkat_OV256_184_72_classic.yml
@@ -35,8 +35,7 @@ jobs:
           - gcc-12
         impl:
           - ref
-          - ssse3
-          - amd64
+          - neon
     runs-on: macos-latest
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/nistkat_OV256_184_72_pkc.yml
+++ b/.github/workflows/nistkat_OV256_184_72_pkc.yml
@@ -26,32 +26,33 @@ jobs:
       run: make KAT=1 PARAM=4 VARIANT=2 PROJ=${{ matrix.impl }} check-NISTKAT
       env:
         CC: ${{ matrix.cc }}
-  test-macos:
-    name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
-    strategy:
-      matrix:
-        cc:
-          - clang
-          - gcc-12
-        impl:
-          - ref
-          - neon
-    runs-on: macos-latest
-    steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Setup openssl
-      run: | 
-        brew install openssl
-    - uses: actions/checkout@v3
-    - name: Set up compiler
-      run: 'export CC=${{ matrix.cc }}'
-    - name: test
-      run: |
-        function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
-        make KAT=1 PARAM=4 VARIANT=2 PROJ=${{ matrix.impl }} check-NISTKAT
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  # TODO: fix this in the Github CI
+  #test-macos:
+  #  name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
+  #  strategy:
+  #    matrix:
+  #      cc:
+  #        - clang
+  #        - gcc-12
+  #      impl:
+  #        - ref
+  #        - neon
+  #  runs-on: macos-latest
+  #  steps:
+  #  - uses: maxim-lobanov/setup-xcode@v1
+  #    with:
+  #      xcode-version: latest-stable
+  #  - name: Setup openssl
+  #    run: | 
+  #      brew install openssl
+  #  - uses: actions/checkout@v3
+  #  - name: Set up compiler
+  #    run: 'export CC=${{ matrix.cc }}'
+  #  - name: test
+  #    run: |
+  #      function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
+  #      make KAT=1 PARAM=4 VARIANT=2 PROJ=${{ matrix.impl }} check-NISTKAT
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/nistkat_OV256_184_72_pkc.yml
+++ b/.github/workflows/nistkat_OV256_184_72_pkc.yml
@@ -35,8 +35,7 @@ jobs:
           - gcc-12
         impl:
           - ref
-          - ssse3
-          - amd64
+          - neon
     runs-on: macos-latest
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/nistkat_OV256_184_72_pkc.yml
+++ b/.github/workflows/nistkat_OV256_184_72_pkc.yml
@@ -2,9 +2,9 @@ name: NISTKAT OV256_184_72_pkc
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
 
 jobs:
   test-ubuntu:
@@ -42,6 +42,9 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Setup openssl
+      run: | 
+        brew install openssl
     - uses: actions/checkout@v3
     - name: Set up compiler
       run: 'export CC=${{ matrix.cc }}'
@@ -51,5 +54,5 @@ jobs:
         make KAT=1 PARAM=4 VARIANT=2 PROJ=${{ matrix.impl }} check-NISTKAT
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/nistkat_OV256_184_72_pkc_skc.yml
+++ b/.github/workflows/nistkat_OV256_184_72_pkc_skc.yml
@@ -2,9 +2,9 @@ name: NISTKAT OV256_184_72_pkc_skc
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
 
 jobs:
   test-ubuntu:
@@ -42,6 +42,9 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Setup openssl
+      run: | 
+        brew install openssl
     - uses: actions/checkout@v3
     - name: Set up compiler
       run: 'export CC=${{ matrix.cc }}'
@@ -51,5 +54,5 @@ jobs:
         make KAT=1 PARAM=4 VARIANT=3 PROJ=${{ matrix.impl }} check-NISTKAT
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/nistkat_OV256_184_72_pkc_skc.yml
+++ b/.github/workflows/nistkat_OV256_184_72_pkc_skc.yml
@@ -35,8 +35,7 @@ jobs:
           - gcc-12
         impl:
           - ref
-          - ssse3
-          - amd64
+          - neon
     runs-on: macos-latest
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/nistkat_OV256_184_72_pkc_skc.yml
+++ b/.github/workflows/nistkat_OV256_184_72_pkc_skc.yml
@@ -26,32 +26,33 @@ jobs:
       run: make KAT=1 PARAM=4 VARIANT=3 PROJ=${{ matrix.impl }} check-NISTKAT
       env:
         CC: ${{ matrix.cc }}
-  test-macos:
-    name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
-    strategy:
-      matrix:
-        cc:
-          - clang
-          - gcc-12
-        impl:
-          - ref
-          - neon
-    runs-on: macos-latest
-    steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Setup openssl
-      run: | 
-        brew install openssl
-    - uses: actions/checkout@v3
-    - name: Set up compiler
-      run: 'export CC=${{ matrix.cc }}'
-    - name: test
-      run: |
-        function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
-        make KAT=1 PARAM=4 VARIANT=3 PROJ=${{ matrix.impl }} check-NISTKAT
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  # TODO: fix this in the Github CI
+  #test-macos:
+  #  name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
+  #  strategy:
+  #    matrix:
+  #      cc:
+  #        - clang
+  #        - gcc-12
+  #      impl:
+  #        - ref
+  #        - neon
+  #  runs-on: macos-latest
+  #  steps:
+  #  - uses: maxim-lobanov/setup-xcode@v1
+  #    with:
+  #      xcode-version: latest-stable
+  #  - name: Setup openssl
+  #    run: | 
+  #      brew install openssl
+  #  - uses: actions/checkout@v3
+  #  - name: Set up compiler
+  #    run: 'export CC=${{ matrix.cc }}'
+  #  - name: test
+  #    run: |
+  #      function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
+  #      make KAT=1 PARAM=4 VARIANT=3 PROJ=${{ matrix.impl }} check-NISTKAT
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/nistkat_OV256_244_96_classic.yml
+++ b/.github/workflows/nistkat_OV256_244_96_classic.yml
@@ -35,8 +35,7 @@ jobs:
           - gcc-12
         impl:
           - ref
-          - ssse3
-          - amd64
+          - neon
     runs-on: macos-latest
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/nistkat_OV256_244_96_classic.yml
+++ b/.github/workflows/nistkat_OV256_244_96_classic.yml
@@ -2,9 +2,9 @@ name: NISTKAT OV256_244_96_classic
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
 
 jobs:
   test-ubuntu:
@@ -42,6 +42,9 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Setup openssl
+      run: | 
+        brew install openssl
     - uses: actions/checkout@v3
     - name: Set up compiler
       run: 'export CC=${{ matrix.cc }}'
@@ -51,5 +54,5 @@ jobs:
         make KAT=1 PARAM=5 VARIANT=1 PROJ=${{ matrix.impl }} check-NISTKAT
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/nistkat_OV256_244_96_classic.yml
+++ b/.github/workflows/nistkat_OV256_244_96_classic.yml
@@ -26,32 +26,33 @@ jobs:
       run: make KAT=1 PARAM=5 VARIANT=1 PROJ=${{ matrix.impl }} check-NISTKAT
       env:
         CC: ${{ matrix.cc }}
-  test-macos:
-    name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
-    strategy:
-      matrix:
-        cc:
-          - clang
-          - gcc-12
-        impl:
-          - ref
-          - neon
-    runs-on: macos-latest
-    steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Setup openssl
-      run: | 
-        brew install openssl
-    - uses: actions/checkout@v3
-    - name: Set up compiler
-      run: 'export CC=${{ matrix.cc }}'
-    - name: test
-      run: |
-        function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
-        make KAT=1 PARAM=5 VARIANT=1 PROJ=${{ matrix.impl }} check-NISTKAT
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  # TODO: fix this in the Github CI
+  #test-macos:
+  #  name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
+  #  strategy:
+  #    matrix:
+  #      cc:
+  #        - clang
+  #        - gcc-12
+  #      impl:
+  #        - ref
+  #        - neon
+  #  runs-on: macos-latest
+  #  steps:
+  #  - uses: maxim-lobanov/setup-xcode@v1
+  #    with:
+  #      xcode-version: latest-stable
+  #  - name: Setup openssl
+  #    run: | 
+  #      brew install openssl
+  #  - uses: actions/checkout@v3
+  #  - name: Set up compiler
+  #    run: 'export CC=${{ matrix.cc }}'
+  #  - name: test
+  #    run: |
+  #      function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
+  #      make KAT=1 PARAM=5 VARIANT=1 PROJ=${{ matrix.impl }} check-NISTKAT
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/nistkat_OV256_244_96_pkc.yml
+++ b/.github/workflows/nistkat_OV256_244_96_pkc.yml
@@ -26,32 +26,33 @@ jobs:
       run: make KAT=1 PARAM=5 VARIANT=2 PROJ=${{ matrix.impl }} check-NISTKAT
       env:
         CC: ${{ matrix.cc }}
-  test-macos:
-    name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
-    strategy:
-      matrix:
-        cc:
-          - clang
-          - gcc-12
-        impl:
-          - ref
-          - neon
-    runs-on: macos-latest
-    steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Setup openssl
-      run: | 
-        brew install openssl
-    - uses: actions/checkout@v3
-    - name: Set up compiler
-      run: 'export CC=${{ matrix.cc }}'
-    - name: test
-      run: |
-        function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
-        make KAT=1 PARAM=5 VARIANT=2 PROJ=${{ matrix.impl }} check-NISTKAT
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  # TODO: fix this in the Github CI
+  #test-macos:
+  #  name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
+  #  strategy:
+  #    matrix:
+  #      cc:
+  #        - clang
+  #        - gcc-12
+  #      impl:
+  #        - ref
+  #        - neon
+  #  runs-on: macos-latest
+  #  steps:
+  #  - uses: maxim-lobanov/setup-xcode@v1
+  #    with:
+  #      xcode-version: latest-stable
+  #  - name: Setup openssl
+  #    run: | 
+  #      brew install openssl
+  #  - uses: actions/checkout@v3
+  #  - name: Set up compiler
+  #    run: 'export CC=${{ matrix.cc }}'
+  #  - name: test
+  #    run: |
+  #      function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
+  #      make KAT=1 PARAM=5 VARIANT=2 PROJ=${{ matrix.impl }} check-NISTKAT
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/nistkat_OV256_244_96_pkc.yml
+++ b/.github/workflows/nistkat_OV256_244_96_pkc.yml
@@ -2,9 +2,9 @@ name: NISTKAT OV256_244_96_pkc
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
 
 jobs:
   test-ubuntu:
@@ -42,6 +42,9 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Setup openssl
+      run: | 
+        brew install openssl
     - uses: actions/checkout@v3
     - name: Set up compiler
       run: 'export CC=${{ matrix.cc }}'
@@ -51,5 +54,5 @@ jobs:
         make KAT=1 PARAM=5 VARIANT=2 PROJ=${{ matrix.impl }} check-NISTKAT
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/nistkat_OV256_244_96_pkc.yml
+++ b/.github/workflows/nistkat_OV256_244_96_pkc.yml
@@ -35,8 +35,7 @@ jobs:
           - gcc-12
         impl:
           - ref
-          - ssse3
-          - amd64
+          - neon
     runs-on: macos-latest
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/nistkat_OV256_244_96_pkc_skc.yml
+++ b/.github/workflows/nistkat_OV256_244_96_pkc_skc.yml
@@ -26,32 +26,33 @@ jobs:
       run: make KAT=1 PARAM=5 VARIANT=3 PROJ=${{ matrix.impl }} check-NISTKAT
       env:
         CC: ${{ matrix.cc }}
-  test-macos:
-    name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
-    strategy:
-      matrix:
-        cc:
-          - clang
-          - gcc-12
-        impl:
-          - ref
-          - neon
-    runs-on: macos-latest
-    steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Setup openssl
-      run: | 
-        brew install openssl
-    - uses: actions/checkout@v3
-    - name: Set up compiler
-      run: 'export CC=${{ matrix.cc }}'
-    - name: test
-      run: |
-        function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
-        make KAT=1 PARAM=5 VARIANT=3 PROJ=${{ matrix.impl }} check-NISTKAT
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  # TODO: fix this in the Github CI
+  #test-macos:
+  #  name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
+  #  strategy:
+  #    matrix:
+  #      cc:
+  #        - clang
+  #        - gcc-12
+  #      impl:
+  #        - ref
+  #        - neon
+  #  runs-on: macos-latest
+  #  steps:
+  #  - uses: maxim-lobanov/setup-xcode@v1
+  #    with:
+  #      xcode-version: latest-stable
+  #  - name: Setup openssl
+  #    run: | 
+  #      brew install openssl
+  #  - uses: actions/checkout@v3
+  #  - name: Set up compiler
+  #    run: 'export CC=${{ matrix.cc }}'
+  #  - name: test
+  #    run: |
+  #      function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
+  #      make KAT=1 PARAM=5 VARIANT=3 PROJ=${{ matrix.impl }} check-NISTKAT
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/nistkat_OV256_244_96_pkc_skc.yml
+++ b/.github/workflows/nistkat_OV256_244_96_pkc_skc.yml
@@ -35,8 +35,7 @@ jobs:
           - gcc-12
         impl:
           - ref
-          - ssse3
-          - amd64
+          - neon
     runs-on: macos-latest
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/nistkat_OV256_244_96_pkc_skc.yml
+++ b/.github/workflows/nistkat_OV256_244_96_pkc_skc.yml
@@ -2,9 +2,9 @@ name: NISTKAT OV256_244_96_pkc_skc
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
 
 jobs:
   test-ubuntu:
@@ -42,6 +42,9 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Setup openssl
+      run: | 
+        brew install openssl
     - uses: actions/checkout@v3
     - name: Set up compiler
       run: 'export CC=${{ matrix.cc }}'
@@ -51,5 +54,5 @@ jobs:
         make KAT=1 PARAM=5 VARIANT=3 PROJ=${{ matrix.impl }} check-NISTKAT
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/test_OV16_160_64_classic.yml
+++ b/.github/workflows/test_OV16_160_64_classic.yml
@@ -56,48 +56,49 @@ jobs:
       run: |
         make VALGRIND=1 PARAM=1 VARIANT=1 PROJ=${{ matrix.impl }} sign_api-test
         valgrind --error-exitcode=1 --exit-on-first-error=yes --leak-check=yes ./sign_api-test
-  test-macos:
-    name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
-    strategy:
-      matrix:
-        cc:
-          - clang
-          - gcc-12
-        impl: # there is no AVX2 available on the MacOS runners
-          - ref
-          - neon
-    runs-on: macos-latest
-    steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Setup openssl
-      run: | 
-        brew install openssl
-    - uses: actions/checkout@v3
-    - name: Set up compiler
-      run: |
-        export CC=${{ matrix.cc }}
-        sysctl -a machdep.cpu  
-    - name: test
-      run: make PARAM=1 VARIANT=1 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
-    - name: asan
-      run: |
-        make clean
-        make ASAN=1 PARAM=1 VARIANT=1 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
-    - name: ubsan
-      run: |
-        make clean
-        make UBSAN=1 PARAM=1 VARIANT=1 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  # TODO: fix this in the Github CI
+  #test-macos:
+  #  name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
+  #  strategy:
+  #    matrix:
+  #      cc:
+  #        - clang
+  #        - gcc-12
+  #      impl: # there is no AVX2 available on the MacOS runners
+  #        - ref
+  #        - neon
+  #  runs-on: macos-latest
+  #  steps:
+  #  - uses: maxim-lobanov/setup-xcode@v1
+  #    with:
+  #      xcode-version: latest-stable
+  #  - name: Setup openssl
+  #    run: | 
+  #      brew install openssl
+  #  - uses: actions/checkout@v3
+  #  - name: Set up compiler
+  #    run: |
+  #      export CC=${{ matrix.cc }}
+  #      sysctl -a machdep.cpu  
+  #  - name: test
+  #    run: make PARAM=1 VARIANT=1 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  #  - name: asan
+  #    run: |
+  #      make clean
+  #      make ASAN=1 PARAM=1 VARIANT=1 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  #  - name: ubsan
+  #    run: |
+  #      make clean
+  #      make UBSAN=1 PARAM=1 VARIANT=1 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/test_OV16_160_64_classic.yml
+++ b/.github/workflows/test_OV16_160_64_classic.yml
@@ -65,37 +65,39 @@ jobs:
           - gcc-12
         impl: # there is no AVX2 available on the MacOS runners
           - ref
-          - ssse3
-          - amd64
+          - neon
     runs-on: macos-latest
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Setup openssl
+      run: | 
+        brew install openssl
     - uses: actions/checkout@v3
     - name: Set up compiler
       run: |
         export CC=${{ matrix.cc }}
-        sysctl -a machdep.cpu
+        sysctl -a machdep.cpu  
     - name: test
       run: make PARAM=1 VARIANT=1 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
     - name: asan
       run: |
         make clean
         make ASAN=1 PARAM=1 VARIANT=1 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
     - name: ubsan
       run: |
         make clean
         make UBSAN=1 PARAM=1 VARIANT=1 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/test_OV16_160_64_classic.yml
+++ b/.github/workflows/test_OV16_160_64_classic.yml
@@ -2,9 +2,9 @@ name: Test OV16_160_64_classic
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
 
 jobs:
   test:

--- a/.github/workflows/test_OV16_160_64_pkc.yml
+++ b/.github/workflows/test_OV16_160_64_pkc.yml
@@ -65,37 +65,39 @@ jobs:
           - gcc-12
         impl: # there is no AVX2 available on the MacOS runners
           - ref
-          - ssse3
-          - amd64
+          - neon
     runs-on: macos-latest
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Setup openssl
+      run: | 
+        brew install openssl
     - uses: actions/checkout@v3
     - name: Set up compiler
       run: |
         export CC=${{ matrix.cc }}
-        sysctl -a machdep.cpu
+        sysctl -a machdep.cpu  
     - name: test
       run: make PARAM=1 VARIANT=2 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
     - name: asan
       run: |
         make clean
         make ASAN=1 PARAM=1 VARIANT=2 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
     - name: ubsan
       run: |
         make clean
         make UBSAN=1 PARAM=1 VARIANT=2 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/test_OV16_160_64_pkc.yml
+++ b/.github/workflows/test_OV16_160_64_pkc.yml
@@ -2,9 +2,9 @@ name: Test OV16_160_64_pkc
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
 
 jobs:
   test:

--- a/.github/workflows/test_OV16_160_64_pkc.yml
+++ b/.github/workflows/test_OV16_160_64_pkc.yml
@@ -56,48 +56,49 @@ jobs:
       run: |
         make VALGRIND=1 PARAM=1 VARIANT=2 PROJ=${{ matrix.impl }} sign_api-test
         valgrind --error-exitcode=1 --exit-on-first-error=yes --leak-check=yes ./sign_api-test
-  test-macos:
-    name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
-    strategy:
-      matrix:
-        cc:
-          - clang
-          - gcc-12
-        impl: # there is no AVX2 available on the MacOS runners
-          - ref
-          - neon
-    runs-on: macos-latest
-    steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Setup openssl
-      run: | 
-        brew install openssl
-    - uses: actions/checkout@v3
-    - name: Set up compiler
-      run: |
-        export CC=${{ matrix.cc }}
-        sysctl -a machdep.cpu  
-    - name: test
-      run: make PARAM=1 VARIANT=2 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
-    - name: asan
-      run: |
-        make clean
-        make ASAN=1 PARAM=1 VARIANT=2 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
-    - name: ubsan
-      run: |
-        make clean
-        make UBSAN=1 PARAM=1 VARIANT=2 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  # TODO: fix this in the Github CI
+  #test-macos:
+  #  name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
+  #  strategy:
+  #    matrix:
+  #      cc:
+  #        - clang
+  #        - gcc-12
+  #      impl: # there is no AVX2 available on the MacOS runners
+  #        - ref
+  #        - neon
+  #  runs-on: macos-latest
+  #  steps:
+  #  - uses: maxim-lobanov/setup-xcode@v1
+  #    with:
+  #      xcode-version: latest-stable
+  #  - name: Setup openssl
+  #    run: | 
+  #      brew install openssl
+  #  - uses: actions/checkout@v3
+  #  - name: Set up compiler
+  #    run: |
+  #      export CC=${{ matrix.cc }}
+  #      sysctl -a machdep.cpu  
+  #  - name: test
+  #    run: make PARAM=1 VARIANT=2 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  #  - name: asan
+  #    run: |
+  #      make clean
+  #      make ASAN=1 PARAM=1 VARIANT=2 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  #  - name: ubsan
+  #    run: |
+  #      make clean
+  #      make UBSAN=1 PARAM=1 VARIANT=2 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/test_OV16_160_64_pkc_skc.yml
+++ b/.github/workflows/test_OV16_160_64_pkc_skc.yml
@@ -2,9 +2,9 @@ name: Test OV16_160_64_pkc_skc
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
 
 jobs:
   test:

--- a/.github/workflows/test_OV16_160_64_pkc_skc.yml
+++ b/.github/workflows/test_OV16_160_64_pkc_skc.yml
@@ -56,48 +56,49 @@ jobs:
       run: |
         make VALGRIND=1 PARAM=1 VARIANT=3 PROJ=${{ matrix.impl }} sign_api-test
         valgrind --error-exitcode=1 --exit-on-first-error=yes --leak-check=yes ./sign_api-test
-  test-macos:
-    name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
-    strategy:
-      matrix:
-        cc:
-          - clang
-          - gcc-12
-        impl: # there is no AVX2 available on the MacOS runners
-          - ref
-          - neon
-    runs-on: macos-latest
-    steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Setup openssl
-      run: | 
-        brew install openssl
-    - uses: actions/checkout@v3
-    - name: Set up compiler
-      run: |
-        export CC=${{ matrix.cc }}
-        sysctl -a machdep.cpu  
-    - name: test
-      run: make PARAM=1 VARIANT=3 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
-    - name: asan
-      run: |
-        make clean
-        make ASAN=1 PARAM=1 VARIANT=3 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
-    - name: ubsan
-      run: |
-        make clean
-        make UBSAN=1 PARAM=1 VARIANT=3 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  # TODO: fix this in the Github CI
+  #test-macos:
+  #  name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
+  #  strategy:
+  #    matrix:
+  #      cc:
+  #        - clang
+  #        - gcc-12
+  #      impl: # there is no AVX2 available on the MacOS runners
+  #        - ref
+  #        - neon
+  #  runs-on: macos-latest
+  #  steps:
+  #  - uses: maxim-lobanov/setup-xcode@v1
+  #    with:
+  #      xcode-version: latest-stable
+  #  - name: Setup openssl
+  #    run: | 
+  #      brew install openssl
+  #  - uses: actions/checkout@v3
+  #  - name: Set up compiler
+  #    run: |
+  #      export CC=${{ matrix.cc }}
+  #      sysctl -a machdep.cpu  
+  #  - name: test
+  #    run: make PARAM=1 VARIANT=3 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  #  - name: asan
+  #    run: |
+  #      make clean
+  #      make ASAN=1 PARAM=1 VARIANT=3 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  #  - name: ubsan
+  #    run: |
+  #      make clean
+  #      make UBSAN=1 PARAM=1 VARIANT=3 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/test_OV16_160_64_pkc_skc.yml
+++ b/.github/workflows/test_OV16_160_64_pkc_skc.yml
@@ -65,37 +65,39 @@ jobs:
           - gcc-12
         impl: # there is no AVX2 available on the MacOS runners
           - ref
-          - ssse3
-          - amd64
+          - neon
     runs-on: macos-latest
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Setup openssl
+      run: | 
+        brew install openssl
     - uses: actions/checkout@v3
     - name: Set up compiler
       run: |
         export CC=${{ matrix.cc }}
-        sysctl -a machdep.cpu
+        sysctl -a machdep.cpu  
     - name: test
       run: make PARAM=1 VARIANT=3 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
     - name: asan
       run: |
         make clean
         make ASAN=1 PARAM=1 VARIANT=3 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
     - name: ubsan
       run: |
         make clean
         make UBSAN=1 PARAM=1 VARIANT=3 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/test_OV256_112_44_classic.yml
+++ b/.github/workflows/test_OV256_112_44_classic.yml
@@ -2,9 +2,9 @@ name: Test OV256_112_44_classic
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
 
 jobs:
   test:

--- a/.github/workflows/test_OV256_112_44_classic.yml
+++ b/.github/workflows/test_OV256_112_44_classic.yml
@@ -65,37 +65,39 @@ jobs:
           - gcc-12
         impl: # there is no AVX2 available on the MacOS runners
           - ref
-          - ssse3
-          - amd64
+          - neon
     runs-on: macos-latest
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Setup openssl
+      run: | 
+        brew install openssl
     - uses: actions/checkout@v3
     - name: Set up compiler
       run: |
         export CC=${{ matrix.cc }}
-        sysctl -a machdep.cpu
+        sysctl -a machdep.cpu  
     - name: test
       run: make PARAM=3 VARIANT=1 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
     - name: asan
       run: |
         make clean
         make ASAN=1 PARAM=3 VARIANT=1 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
     - name: ubsan
       run: |
         make clean
         make UBSAN=1 PARAM=3 VARIANT=1 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/test_OV256_112_44_classic.yml
+++ b/.github/workflows/test_OV256_112_44_classic.yml
@@ -56,48 +56,49 @@ jobs:
       run: |
         make VALGRIND=1 PARAM=3 VARIANT=1 PROJ=${{ matrix.impl }} sign_api-test
         valgrind --error-exitcode=1 --exit-on-first-error=yes --leak-check=yes ./sign_api-test
-  test-macos:
-    name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
-    strategy:
-      matrix:
-        cc:
-          - clang
-          - gcc-12
-        impl: # there is no AVX2 available on the MacOS runners
-          - ref
-          - neon
-    runs-on: macos-latest
-    steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Setup openssl
-      run: | 
-        brew install openssl
-    - uses: actions/checkout@v3
-    - name: Set up compiler
-      run: |
-        export CC=${{ matrix.cc }}
-        sysctl -a machdep.cpu  
-    - name: test
-      run: make PARAM=3 VARIANT=1 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
-    - name: asan
-      run: |
-        make clean
-        make ASAN=1 PARAM=3 VARIANT=1 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
-    - name: ubsan
-      run: |
-        make clean
-        make UBSAN=1 PARAM=3 VARIANT=1 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  # TODO: fix this in the Github CI
+  #test-macos:
+  #  name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
+  #  strategy:
+  #    matrix:
+  #      cc:
+  #        - clang
+  #        - gcc-12
+  #      impl: # there is no AVX2 available on the MacOS runners
+  #        - ref
+  #        - neon
+  #  runs-on: macos-latest
+  #  steps:
+  #  - uses: maxim-lobanov/setup-xcode@v1
+  #    with:
+  #      xcode-version: latest-stable
+  #  - name: Setup openssl
+  #    run: | 
+  #      brew install openssl
+  #  - uses: actions/checkout@v3
+  #  - name: Set up compiler
+  #    run: |
+  #      export CC=${{ matrix.cc }}
+  #      sysctl -a machdep.cpu  
+  #  - name: test
+  #    run: make PARAM=3 VARIANT=1 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  #  - name: asan
+  #    run: |
+  #      make clean
+  #      make ASAN=1 PARAM=3 VARIANT=1 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  #  - name: ubsan
+  #    run: |
+  #      make clean
+  #      make UBSAN=1 PARAM=3 VARIANT=1 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/test_OV256_112_44_pkc.yml
+++ b/.github/workflows/test_OV256_112_44_pkc.yml
@@ -65,37 +65,39 @@ jobs:
           - gcc-12
         impl: # there is no AVX2 available on the MacOS runners
           - ref
-          - ssse3
-          - amd64
+          - neon
     runs-on: macos-latest
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Setup openssl
+      run: | 
+        brew install openssl
     - uses: actions/checkout@v3
     - name: Set up compiler
       run: |
         export CC=${{ matrix.cc }}
-        sysctl -a machdep.cpu
+        sysctl -a machdep.cpu  
     - name: test
       run: make PARAM=3 VARIANT=2 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
     - name: asan
       run: |
         make clean
         make ASAN=1 PARAM=3 VARIANT=2 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
     - name: ubsan
       run: |
         make clean
         make UBSAN=1 PARAM=3 VARIANT=2 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/test_OV256_112_44_pkc.yml
+++ b/.github/workflows/test_OV256_112_44_pkc.yml
@@ -2,9 +2,9 @@ name: Test OV256_112_44_pkc
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
 
 jobs:
   test:

--- a/.github/workflows/test_OV256_112_44_pkc.yml
+++ b/.github/workflows/test_OV256_112_44_pkc.yml
@@ -56,48 +56,49 @@ jobs:
       run: |
         make VALGRIND=1 PARAM=3 VARIANT=2 PROJ=${{ matrix.impl }} sign_api-test
         valgrind --error-exitcode=1 --exit-on-first-error=yes --leak-check=yes ./sign_api-test
-  test-macos:
-    name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
-    strategy:
-      matrix:
-        cc:
-          - clang
-          - gcc-12
-        impl: # there is no AVX2 available on the MacOS runners
-          - ref
-          - neon
-    runs-on: macos-latest
-    steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Setup openssl
-      run: | 
-        brew install openssl
-    - uses: actions/checkout@v3
-    - name: Set up compiler
-      run: |
-        export CC=${{ matrix.cc }}
-        sysctl -a machdep.cpu  
-    - name: test
-      run: make PARAM=3 VARIANT=2 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
-    - name: asan
-      run: |
-        make clean
-        make ASAN=1 PARAM=3 VARIANT=2 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
-    - name: ubsan
-      run: |
-        make clean
-        make UBSAN=1 PARAM=3 VARIANT=2 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  # TODO: fix this in the Github CI
+  #test-macos:
+  #  name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
+  #  strategy:
+  #    matrix:
+  #      cc:
+  #        - clang
+  #        - gcc-12
+  #      impl: # there is no AVX2 available on the MacOS runners
+  #        - ref
+  #        - neon
+  #  runs-on: macos-latest
+  #  steps:
+  #  - uses: maxim-lobanov/setup-xcode@v1
+  #    with:
+  #      xcode-version: latest-stable
+  #  - name: Setup openssl
+  #    run: | 
+  #      brew install openssl
+  #  - uses: actions/checkout@v3
+  #  - name: Set up compiler
+  #    run: |
+  #      export CC=${{ matrix.cc }}
+  #      sysctl -a machdep.cpu  
+  #  - name: test
+  #    run: make PARAM=3 VARIANT=2 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  #  - name: asan
+  #    run: |
+  #      make clean
+  #      make ASAN=1 PARAM=3 VARIANT=2 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  #  - name: ubsan
+  #    run: |
+  #      make clean
+  #      make UBSAN=1 PARAM=3 VARIANT=2 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/test_OV256_112_44_pkc_skc.yml
+++ b/.github/workflows/test_OV256_112_44_pkc_skc.yml
@@ -2,9 +2,9 @@ name: Test OV256_112_44_pkc_skc
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
 
 jobs:
   test:

--- a/.github/workflows/test_OV256_112_44_pkc_skc.yml
+++ b/.github/workflows/test_OV256_112_44_pkc_skc.yml
@@ -56,48 +56,49 @@ jobs:
       run: |
         make VALGRIND=1 PARAM=3 VARIANT=3 PROJ=${{ matrix.impl }} sign_api-test
         valgrind --error-exitcode=1 --exit-on-first-error=yes --leak-check=yes ./sign_api-test
-  test-macos:
-    name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
-    strategy:
-      matrix:
-        cc:
-          - clang
-          - gcc-12
-        impl: # there is no AVX2 available on the MacOS runners
-          - ref
-          - neon
-    runs-on: macos-latest
-    steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Setup openssl
-      run: | 
-        brew install openssl
-    - uses: actions/checkout@v3
-    - name: Set up compiler
-      run: |
-        export CC=${{ matrix.cc }}
-        sysctl -a machdep.cpu  
-    - name: test
-      run: make PARAM=3 VARIANT=3 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
-    - name: asan
-      run: |
-        make clean
-        make ASAN=1 PARAM=3 VARIANT=3 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
-    - name: ubsan
-      run: |
-        make clean
-        make UBSAN=1 PARAM=3 VARIANT=3 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  # TODO: fix this in the Github CI
+  #test-macos:
+  #  name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
+  #  strategy:
+  #    matrix:
+  #      cc:
+  #        - clang
+  #        - gcc-12
+  #      impl: # there is no AVX2 available on the MacOS runners
+  #        - ref
+  #        - neon
+  #  runs-on: macos-latest
+  #  steps:
+  #  - uses: maxim-lobanov/setup-xcode@v1
+  #    with:
+  #      xcode-version: latest-stable
+  #  - name: Setup openssl
+  #    run: | 
+  #      brew install openssl
+  #  - uses: actions/checkout@v3
+  #  - name: Set up compiler
+  #    run: |
+  #      export CC=${{ matrix.cc }}
+  #      sysctl -a machdep.cpu  
+  #  - name: test
+  #    run: make PARAM=3 VARIANT=3 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  #  - name: asan
+  #    run: |
+  #      make clean
+  #      make ASAN=1 PARAM=3 VARIANT=3 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  #  - name: ubsan
+  #    run: |
+  #      make clean
+  #      make UBSAN=1 PARAM=3 VARIANT=3 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/test_OV256_112_44_pkc_skc.yml
+++ b/.github/workflows/test_OV256_112_44_pkc_skc.yml
@@ -65,37 +65,39 @@ jobs:
           - gcc-12
         impl: # there is no AVX2 available on the MacOS runners
           - ref
-          - ssse3
-          - amd64
+          - neon
     runs-on: macos-latest
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Setup openssl
+      run: | 
+        brew install openssl
     - uses: actions/checkout@v3
     - name: Set up compiler
       run: |
         export CC=${{ matrix.cc }}
-        sysctl -a machdep.cpu
+        sysctl -a machdep.cpu  
     - name: test
       run: make PARAM=3 VARIANT=3 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
     - name: asan
       run: |
         make clean
         make ASAN=1 PARAM=3 VARIANT=3 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
     - name: ubsan
       run: |
         make clean
         make UBSAN=1 PARAM=3 VARIANT=3 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/test_OV256_184_72_classic.yml
+++ b/.github/workflows/test_OV256_184_72_classic.yml
@@ -2,9 +2,9 @@ name: Test OV256_184_72_classic
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
 
 jobs:
   test:

--- a/.github/workflows/test_OV256_184_72_classic.yml
+++ b/.github/workflows/test_OV256_184_72_classic.yml
@@ -65,37 +65,39 @@ jobs:
           - gcc-12
         impl: # there is no AVX2 available on the MacOS runners
           - ref
-          - ssse3
-          - amd64
+          - neon
     runs-on: macos-latest
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Setup openssl
+      run: | 
+        brew install openssl
     - uses: actions/checkout@v3
     - name: Set up compiler
       run: |
         export CC=${{ matrix.cc }}
-        sysctl -a machdep.cpu
+        sysctl -a machdep.cpu  
     - name: test
       run: make PARAM=4 VARIANT=1 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
     - name: asan
       run: |
         make clean
         make ASAN=1 PARAM=4 VARIANT=1 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
     - name: ubsan
       run: |
         make clean
         make UBSAN=1 PARAM=4 VARIANT=1 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/test_OV256_184_72_classic.yml
+++ b/.github/workflows/test_OV256_184_72_classic.yml
@@ -56,48 +56,49 @@ jobs:
       run: |
         make VALGRIND=1 PARAM=4 VARIANT=1 PROJ=${{ matrix.impl }} sign_api-test
         valgrind --error-exitcode=1 --exit-on-first-error=yes --leak-check=yes ./sign_api-test
-  test-macos:
-    name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
-    strategy:
-      matrix:
-        cc:
-          - clang
-          - gcc-12
-        impl: # there is no AVX2 available on the MacOS runners
-          - ref
-          - neon
-    runs-on: macos-latest
-    steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Setup openssl
-      run: | 
-        brew install openssl
-    - uses: actions/checkout@v3
-    - name: Set up compiler
-      run: |
-        export CC=${{ matrix.cc }}
-        sysctl -a machdep.cpu  
-    - name: test
-      run: make PARAM=4 VARIANT=1 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
-    - name: asan
-      run: |
-        make clean
-        make ASAN=1 PARAM=4 VARIANT=1 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
-    - name: ubsan
-      run: |
-        make clean
-        make UBSAN=1 PARAM=4 VARIANT=1 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  # TODO: fix this in the Github CI
+  #test-macos:
+  #  name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
+  #  strategy:
+  #    matrix:
+  #      cc:
+  #        - clang
+  #        - gcc-12
+  #      impl: # there is no AVX2 available on the MacOS runners
+  #        - ref
+  #        - neon
+  #  runs-on: macos-latest
+  #  steps:
+  #  - uses: maxim-lobanov/setup-xcode@v1
+  #    with:
+  #      xcode-version: latest-stable
+  #  - name: Setup openssl
+  #    run: | 
+  #      brew install openssl
+  #  - uses: actions/checkout@v3
+  #  - name: Set up compiler
+  #    run: |
+  #      export CC=${{ matrix.cc }}
+  #      sysctl -a machdep.cpu  
+  #  - name: test
+  #    run: make PARAM=4 VARIANT=1 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  #  - name: asan
+  #    run: |
+  #      make clean
+  #      make ASAN=1 PARAM=4 VARIANT=1 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  #  - name: ubsan
+  #    run: |
+  #      make clean
+  #      make UBSAN=1 PARAM=4 VARIANT=1 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/test_OV256_184_72_pkc.yml
+++ b/.github/workflows/test_OV256_184_72_pkc.yml
@@ -2,9 +2,9 @@ name: Test OV256_184_72_pkc
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
 
 jobs:
   test:

--- a/.github/workflows/test_OV256_184_72_pkc.yml
+++ b/.github/workflows/test_OV256_184_72_pkc.yml
@@ -56,48 +56,49 @@ jobs:
       run: |
         make VALGRIND=1 PARAM=4 VARIANT=2 PROJ=${{ matrix.impl }} sign_api-test
         valgrind --error-exitcode=1 --exit-on-first-error=yes --leak-check=yes ./sign_api-test
-  test-macos:
-    name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
-    strategy:
-      matrix:
-        cc:
-          - clang
-          - gcc-12
-        impl: # there is no AVX2 available on the MacOS runners
-          - ref
-          - neon
-    runs-on: macos-latest
-    steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Setup openssl
-      run: | 
-        brew install openssl
-    - uses: actions/checkout@v3
-    - name: Set up compiler
-      run: |
-        export CC=${{ matrix.cc }}
-        sysctl -a machdep.cpu  
-    - name: test
-      run: make PARAM=4 VARIANT=2 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
-    - name: asan
-      run: |
-        make clean
-        make ASAN=1 PARAM=4 VARIANT=2 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
-    - name: ubsan
-      run: |
-        make clean
-        make UBSAN=1 PARAM=4 VARIANT=2 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  # TODO: fix this in the Github CI
+  #test-macos:
+  #  name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
+  #  strategy:
+  #    matrix:
+  #      cc:
+  #        - clang
+  #        - gcc-12
+  #      impl: # there is no AVX2 available on the MacOS runners
+  #        - ref
+  #        - neon
+  #  runs-on: macos-latest
+  #  steps:
+  #  - uses: maxim-lobanov/setup-xcode@v1
+  #    with:
+  #      xcode-version: latest-stable
+  #  - name: Setup openssl
+  #    run: | 
+  #      brew install openssl
+  #  - uses: actions/checkout@v3
+  #  - name: Set up compiler
+  #    run: |
+  #      export CC=${{ matrix.cc }}
+  #      sysctl -a machdep.cpu  
+  #  - name: test
+  #    run: make PARAM=4 VARIANT=2 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  #  - name: asan
+  #    run: |
+  #      make clean
+  #      make ASAN=1 PARAM=4 VARIANT=2 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  #  - name: ubsan
+  #    run: |
+  #      make clean
+  #      make UBSAN=1 PARAM=4 VARIANT=2 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/test_OV256_184_72_pkc.yml
+++ b/.github/workflows/test_OV256_184_72_pkc.yml
@@ -65,37 +65,39 @@ jobs:
           - gcc-12
         impl: # there is no AVX2 available on the MacOS runners
           - ref
-          - ssse3
-          - amd64
+          - neon
     runs-on: macos-latest
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Setup openssl
+      run: | 
+        brew install openssl
     - uses: actions/checkout@v3
     - name: Set up compiler
       run: |
         export CC=${{ matrix.cc }}
-        sysctl -a machdep.cpu
+        sysctl -a machdep.cpu  
     - name: test
       run: make PARAM=4 VARIANT=2 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
     - name: asan
       run: |
         make clean
         make ASAN=1 PARAM=4 VARIANT=2 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
     - name: ubsan
       run: |
         make clean
         make UBSAN=1 PARAM=4 VARIANT=2 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/test_OV256_184_72_pkc_skc.yml
+++ b/.github/workflows/test_OV256_184_72_pkc_skc.yml
@@ -65,37 +65,39 @@ jobs:
           - gcc-12
         impl: # there is no AVX2 available on the MacOS runners
           - ref
-          - ssse3
-          - amd64
+          - neon
     runs-on: macos-latest
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Setup openssl
+      run: | 
+        brew install openssl
     - uses: actions/checkout@v3
     - name: Set up compiler
       run: |
         export CC=${{ matrix.cc }}
-        sysctl -a machdep.cpu
+        sysctl -a machdep.cpu  
     - name: test
       run: make PARAM=4 VARIANT=3 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
     - name: asan
       run: |
         make clean
         make ASAN=1 PARAM=4 VARIANT=3 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
     - name: ubsan
       run: |
         make clean
         make UBSAN=1 PARAM=4 VARIANT=3 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/test_OV256_184_72_pkc_skc.yml
+++ b/.github/workflows/test_OV256_184_72_pkc_skc.yml
@@ -56,48 +56,49 @@ jobs:
       run: |
         make VALGRIND=1 PARAM=4 VARIANT=3 PROJ=${{ matrix.impl }} sign_api-test
         valgrind --error-exitcode=1 --exit-on-first-error=yes --leak-check=yes ./sign_api-test
-  test-macos:
-    name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
-    strategy:
-      matrix:
-        cc:
-          - clang
-          - gcc-12
-        impl: # there is no AVX2 available on the MacOS runners
-          - ref
-          - neon
-    runs-on: macos-latest
-    steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Setup openssl
-      run: | 
-        brew install openssl
-    - uses: actions/checkout@v3
-    - name: Set up compiler
-      run: |
-        export CC=${{ matrix.cc }}
-        sysctl -a machdep.cpu  
-    - name: test
-      run: make PARAM=4 VARIANT=3 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
-    - name: asan
-      run: |
-        make clean
-        make ASAN=1 PARAM=4 VARIANT=3 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
-    - name: ubsan
-      run: |
-        make clean
-        make UBSAN=1 PARAM=4 VARIANT=3 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  # TODO: fix this in the Github CI
+  #test-macos:
+  #  name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
+  #  strategy:
+  #    matrix:
+  #      cc:
+  #        - clang
+  #        - gcc-12
+  #      impl: # there is no AVX2 available on the MacOS runners
+  #        - ref
+  #        - neon
+  #  runs-on: macos-latest
+  #  steps:
+  #  - uses: maxim-lobanov/setup-xcode@v1
+  #    with:
+  #      xcode-version: latest-stable
+  #  - name: Setup openssl
+  #    run: | 
+  #      brew install openssl
+  #  - uses: actions/checkout@v3
+  #  - name: Set up compiler
+  #    run: |
+  #      export CC=${{ matrix.cc }}
+  #      sysctl -a machdep.cpu  
+  #  - name: test
+  #    run: make PARAM=4 VARIANT=3 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  #  - name: asan
+  #    run: |
+  #      make clean
+  #      make ASAN=1 PARAM=4 VARIANT=3 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  #  - name: ubsan
+  #    run: |
+  #      make clean
+  #      make UBSAN=1 PARAM=4 VARIANT=3 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/test_OV256_184_72_pkc_skc.yml
+++ b/.github/workflows/test_OV256_184_72_pkc_skc.yml
@@ -2,9 +2,9 @@ name: Test OV256_184_72_pkc_skc
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
 
 jobs:
   test:

--- a/.github/workflows/test_OV256_244_96_classic.yml
+++ b/.github/workflows/test_OV256_244_96_classic.yml
@@ -2,9 +2,9 @@ name: Test OV256_244_96_classic
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
 
 jobs:
   test:

--- a/.github/workflows/test_OV256_244_96_classic.yml
+++ b/.github/workflows/test_OV256_244_96_classic.yml
@@ -65,37 +65,39 @@ jobs:
           - gcc-12
         impl: # there is no AVX2 available on the MacOS runners
           - ref
-          - ssse3
-          - amd64
+          - neon
     runs-on: macos-latest
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Setup openssl
+      run: | 
+        brew install openssl
     - uses: actions/checkout@v3
     - name: Set up compiler
       run: |
         export CC=${{ matrix.cc }}
-        sysctl -a machdep.cpu
+        sysctl -a machdep.cpu  
     - name: test
       run: make PARAM=5 VARIANT=1 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
     - name: asan
       run: |
         make clean
         make ASAN=1 PARAM=5 VARIANT=1 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
     - name: ubsan
       run: |
         make clean
         make UBSAN=1 PARAM=5 VARIANT=1 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/test_OV256_244_96_classic.yml
+++ b/.github/workflows/test_OV256_244_96_classic.yml
@@ -56,48 +56,49 @@ jobs:
       run: |
         make VALGRIND=1 PARAM=5 VARIANT=1 PROJ=${{ matrix.impl }} sign_api-test
         valgrind --error-exitcode=1 --exit-on-first-error=yes --leak-check=yes ./sign_api-test
-  test-macos:
-    name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
-    strategy:
-      matrix:
-        cc:
-          - clang
-          - gcc-12
-        impl: # there is no AVX2 available on the MacOS runners
-          - ref
-          - neon
-    runs-on: macos-latest
-    steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Setup openssl
-      run: | 
-        brew install openssl
-    - uses: actions/checkout@v3
-    - name: Set up compiler
-      run: |
-        export CC=${{ matrix.cc }}
-        sysctl -a machdep.cpu  
-    - name: test
-      run: make PARAM=5 VARIANT=1 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
-    - name: asan
-      run: |
-        make clean
-        make ASAN=1 PARAM=5 VARIANT=1 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
-    - name: ubsan
-      run: |
-        make clean
-        make UBSAN=1 PARAM=5 VARIANT=1 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  # TODO: fix this in the Github CI
+  #test-macos:
+  #  name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
+  #  strategy:
+  #    matrix:
+  #      cc:
+  #        - clang
+  #        - gcc-12
+  #      impl: # there is no AVX2 available on the MacOS runners
+  #        - ref
+  #        - neon
+  #  runs-on: macos-latest
+  #  steps:
+  #  - uses: maxim-lobanov/setup-xcode@v1
+  #    with:
+  #      xcode-version: latest-stable
+  #  - name: Setup openssl
+  #    run: | 
+  #      brew install openssl
+  #  - uses: actions/checkout@v3
+  #  - name: Set up compiler
+  #    run: |
+  #      export CC=${{ matrix.cc }}
+  #      sysctl -a machdep.cpu  
+  #  - name: test
+  #    run: make PARAM=5 VARIANT=1 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  #  - name: asan
+  #    run: |
+  #      make clean
+  #      make ASAN=1 PARAM=5 VARIANT=1 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  #  - name: ubsan
+  #    run: |
+  #      make clean
+  #      make UBSAN=1 PARAM=5 VARIANT=1 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/test_OV256_244_96_pkc.yml
+++ b/.github/workflows/test_OV256_244_96_pkc.yml
@@ -56,48 +56,49 @@ jobs:
       run: |
         make VALGRIND=1 PARAM=5 VARIANT=2 PROJ=${{ matrix.impl }} sign_api-test
         valgrind --error-exitcode=1 --exit-on-first-error=yes --leak-check=yes ./sign_api-test
-  test-macos:
-    name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
-    strategy:
-      matrix:
-        cc:
-          - clang
-          - gcc-12
-        impl: # there is no AVX2 available on the MacOS runners
-          - ref
-          - neon
-    runs-on: macos-latest
-    steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Setup openssl
-      run: | 
-        brew install openssl
-    - uses: actions/checkout@v3
-    - name: Set up compiler
-      run: |
-        export CC=${{ matrix.cc }}
-        sysctl -a machdep.cpu  
-    - name: test
-      run: make PARAM=5 VARIANT=2 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
-    - name: asan
-      run: |
-        make clean
-        make ASAN=1 PARAM=5 VARIANT=2 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
-    - name: ubsan
-      run: |
-        make clean
-        make UBSAN=1 PARAM=5 VARIANT=2 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  # TODO: fix this in the Github CI
+  #test-macos:
+  #  name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
+  #  strategy:
+  #    matrix:
+  #      cc:
+  #        - clang
+  #        - gcc-12
+  #      impl: # there is no AVX2 available on the MacOS runners
+  #        - ref
+  #        - neon
+  #  runs-on: macos-latest
+  #  steps:
+  #  - uses: maxim-lobanov/setup-xcode@v1
+  #    with:
+  #      xcode-version: latest-stable
+  #  - name: Setup openssl
+  #    run: | 
+  #      brew install openssl
+  #  - uses: actions/checkout@v3
+  #  - name: Set up compiler
+  #    run: |
+  #      export CC=${{ matrix.cc }}
+  #      sysctl -a machdep.cpu  
+  #  - name: test
+  #    run: make PARAM=5 VARIANT=2 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  #  - name: asan
+  #    run: |
+  #      make clean
+  #      make ASAN=1 PARAM=5 VARIANT=2 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  #  - name: ubsan
+  #    run: |
+  #      make clean
+  #      make UBSAN=1 PARAM=5 VARIANT=2 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/test_OV256_244_96_pkc.yml
+++ b/.github/workflows/test_OV256_244_96_pkc.yml
@@ -65,37 +65,39 @@ jobs:
           - gcc-12
         impl: # there is no AVX2 available on the MacOS runners
           - ref
-          - ssse3
-          - amd64
+          - neon
     runs-on: macos-latest
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Setup openssl
+      run: | 
+        brew install openssl
     - uses: actions/checkout@v3
     - name: Set up compiler
       run: |
         export CC=${{ matrix.cc }}
-        sysctl -a machdep.cpu
+        sysctl -a machdep.cpu  
     - name: test
       run: make PARAM=5 VARIANT=2 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
     - name: asan
       run: |
         make clean
         make ASAN=1 PARAM=5 VARIANT=2 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
     - name: ubsan
       run: |
         make clean
         make UBSAN=1 PARAM=5 VARIANT=2 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/test_OV256_244_96_pkc.yml
+++ b/.github/workflows/test_OV256_244_96_pkc.yml
@@ -2,9 +2,9 @@ name: Test OV256_244_96_pkc
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
 
 jobs:
   test:

--- a/.github/workflows/test_OV256_244_96_pkc_skc.yml
+++ b/.github/workflows/test_OV256_244_96_pkc_skc.yml
@@ -56,48 +56,49 @@ jobs:
       run: |
         make VALGRIND=1 PARAM=5 VARIANT=3 PROJ=${{ matrix.impl }} sign_api-test
         valgrind --error-exitcode=1 --exit-on-first-error=yes --leak-check=yes ./sign_api-test
-  test-macos:
-    name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
-    strategy:
-      matrix:
-        cc:
-          - clang
-          - gcc-12
-        impl: # there is no AVX2 available on the MacOS runners
-          - ref
-          - neon
-    runs-on: macos-latest
-    steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Setup openssl
-      run: | 
-        brew install openssl
-    - uses: actions/checkout@v3
-    - name: Set up compiler
-      run: |
-        export CC=${{ matrix.cc }}
-        sysctl -a machdep.cpu  
-    - name: test
-      run: make PARAM=5 VARIANT=3 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
-    - name: asan
-      run: |
-        make clean
-        make ASAN=1 PARAM=5 VARIANT=3 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
-    - name: ubsan
-      run: |
-        make clean
-        make UBSAN=1 PARAM=5 VARIANT=3 PROJ=${{ matrix.impl }} test
-      env:
-        CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  # TODO: fix this in the Github CI
+  #test-macos:
+  #  name: MacOS ${{ matrix.impl }} ${{ matrix.cc }}
+  #  strategy:
+  #    matrix:
+  #      cc:
+  #        - clang
+  #        - gcc-12
+  #      impl: # there is no AVX2 available on the MacOS runners
+  #        - ref
+  #        - neon
+  #  runs-on: macos-latest
+  #  steps:
+  #  - uses: maxim-lobanov/setup-xcode@v1
+  #    with:
+  #      xcode-version: latest-stable
+  #  - name: Setup openssl
+  #    run: | 
+  #      brew install openssl
+  #  - uses: actions/checkout@v3
+  #  - name: Set up compiler
+  #    run: |
+  #      export CC=${{ matrix.cc }}
+  #      sysctl -a machdep.cpu  
+  #  - name: test
+  #    run: make PARAM=5 VARIANT=3 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  #  - name: asan
+  #    run: |
+  #      make clean
+  #      make ASAN=1 PARAM=5 VARIANT=3 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+  #  - name: ubsan
+  #    run: |
+  #      make clean
+  #      make UBSAN=1 PARAM=5 VARIANT=3 PROJ=${{ matrix.impl }} test
+  #    env:
+  #      CC: ${{ matrix.cc }}
+  #      LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+  #      CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/.github/workflows/test_OV256_244_96_pkc_skc.yml
+++ b/.github/workflows/test_OV256_244_96_pkc_skc.yml
@@ -2,9 +2,9 @@ name: Test OV256_244_96_pkc_skc
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "r2"]
 
 jobs:
   test:

--- a/.github/workflows/test_OV256_244_96_pkc_skc.yml
+++ b/.github/workflows/test_OV256_244_96_pkc_skc.yml
@@ -65,37 +65,39 @@ jobs:
           - gcc-12
         impl: # there is no AVX2 available on the MacOS runners
           - ref
-          - ssse3
-          - amd64
+          - neon
     runs-on: macos-latest
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Setup openssl
+      run: | 
+        brew install openssl
     - uses: actions/checkout@v3
     - name: Set up compiler
       run: |
         export CC=${{ matrix.cc }}
-        sysctl -a machdep.cpu
+        sysctl -a machdep.cpu  
     - name: test
       run: make PARAM=5 VARIANT=3 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
     - name: asan
       run: |
         make clean
         make ASAN=1 PARAM=5 VARIANT=3 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
     - name: ubsan
       run: |
         make clean
         make UBSAN=1 PARAM=5 VARIANT=3 PROJ=${{ matrix.impl }} test
       env:
         CC: ${{ matrix.cc }}
-        LDFLAGS: "-L/usr/local/opt/openssl@3/lib"
-        CFLAGS: "-I/usr/local/opt/openssl@3/include"
+        LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+        CFLAGS: "-I/opt/homebrew/opt/openssl@3/include"

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,8 @@ else ifeq ($(PROJ),neon)
 ifeq ($(OS), Darwin)
 SRC_EXT_DIRS  = ./src/ref ./src/amd64 ./src/neon  ./utils/neon_aesinst
 INCPATH      += -I./src/ref -I./src/amd64 -I./src/neon  -I./utils/neon_aesinst
-CFLAGS    += -D_BLAS_NEON_ -D_UTILS_NEONAES_ -flax-vector-conversions
-CXXFLAGS  += -D_BLAS_NEON_ -D_UTILS_NEONAES_ -flax-vector-conversions
+CFLAGS    += -D_BLAS_NEON_ -D_UTILS_NEONAES_ -flax-vector-conversions -march=armv8-a+aes
+CXXFLAGS  += -D_BLAS_NEON_ -D_UTILS_NEONAES_ -flax-vector-conversions -march=armv8-a+aes
 else
 SRC_EXT_DIRS  = ./src/ref ./src/amd64 ./src/neon  ./utils/neon_aesffs
 INCPATH      += -I./src/ref -I./src/amd64 -I./src/neon  -I./utils/neon_aesffs

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,8 @@ else ifeq ($(PROJ),neon)
 ifeq ($(OS), Darwin)
 SRC_EXT_DIRS  = ./src/ref ./src/amd64 ./src/neon  ./utils/neon_aesinst
 INCPATH      += -I./src/ref -I./src/amd64 -I./src/neon  -I./utils/neon_aesinst
-CFLAGS    += -D_BLAS_NEON_ -D_UTILS_NEONAES_
-CXXFLAGS  += -D_BLAS_NEON_ -D_UTILS_NEONAES_
+CFLAGS    += -D_BLAS_NEON_ -D_UTILS_NEONAES_ -flax-vector-conversions
+CXXFLAGS  += -D_BLAS_NEON_ -D_UTILS_NEONAES_ -flax-vector-conversions
 else
 SRC_EXT_DIRS  = ./src/ref ./src/amd64 ./src/neon  ./utils/neon_aesffs
 INCPATH      += -I./src/ref -I./src/amd64 -I./src/neon  -I./utils/neon_aesffs

--- a/benchmark/m1cycles.c
+++ b/benchmark/m1cycles.c
@@ -92,6 +92,11 @@ static void init_rdtsc(void) {
         printf("kperf = %p\n", kperf);
         return;
     }
+/* Temporarily disable -Wpedantic here to allow conversion
+ * from (void *) to function-pointer.
+ */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #define F(ret, name, ...)                         \
     name = (name##proc *)(dlsym(kperf, #name));   \
     if (!name)                                    \
@@ -101,6 +106,7 @@ static void init_rdtsc(void) {
     }
     KPERF_LIST
 #undef F
+#pragma GCC diagnostic pop
 
     // TODO: KPC_CLASS_RAWPMU_MASK
 

--- a/benchmark/m1cycles.c
+++ b/benchmark/m1cycles.c
@@ -62,7 +62,7 @@ KPERF_LIST
 uint64_t g_counters[COUNTERS_COUNT];
 uint64_t g_config[COUNTERS_COUNT];
 
-static void configure_rdtsc() {
+static void configure_rdtsc(void) {
     if (kpc_set_config(KPC_MASK, g_config)) {
         printf("kpc_set_config failed (root?)\n");
         return;
@@ -84,7 +84,7 @@ static void configure_rdtsc() {
     }
 }
 
-static void init_rdtsc() {
+static void init_rdtsc(void) {
     void *kperf = dlopen(
                       "/System/Library/PrivateFrameworks/kperf.framework/Versions/A/kperf",
                       RTLD_LAZY);


### PR DESCRIPTION
This PR fixes the Neon implementations to run successfully on Apple Silicon (gcc + clang). 

I tested the following on Apple M4: 
```
CFLAGS="-I/opt/homebrew/opt/openssl@3/include" LDFLAGS="-L/opt/homebrew/opt/openssl@3/lib" ./run_pqcgenkat.sh
```
After that testvectors are matching what we currently have in git. 

It also works with gcc:
```
gcc --version
gcc (GCC) 14.2.0
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

CFLAGS="-I/opt/homebrew/opt/openssl@3/include" LDFLAGS="-L/opt/homebrew/opt/openssl@3/lib" CC=gcc ./run_pqcgenkat.sh
```


It also adjusts the CI to run on the M1-based macos github runners. Unfortunately, there is currently some problem with the macos github runners, so I had to temporarily disable the MacOS CI. I will renable it once I find a solution. 