### PR TITLE
Remove reduced number of cadd in GE

### DIFF
--- a/src/avx2/blas_matrix_avx2.c
+++ b/src/avx2/blas_matrix_avx2.c
@@ -19,12 +19,7 @@
 
 #include "string.h"
 
-
 #include "params.h"  // for macro _USE_GF16
-
-
-#define _GE_CADD_EARLY_STOP_
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////  matrix-vector multiplication, GF( 16 ) ////////////////////
@@ -712,12 +707,12 @@ unsigned _gf16mat_sol_64x64_avx2( uint8_t *mat, __m256i *vec) {
 
         __m256i rowi = _mm256_load_si256( (__m256i *)(mat + i * w_byte) );
 
-        #if defined( _GE_CADD_EARLY_STOP_ )
-        unsigned stop = (i + 16 < h) ? i + 16 : h;
+#if defined( _GE_CONST_TIME_CADD_EARLY_STOP_ )   // defined in config.h
+        unsigned stop = (i + _GE_EARLY_STOP_STEPS_GF16_ < h) ? i + _GE_EARLY_STOP_STEPS_GF16_ : h;
         for (unsigned j = i + 1; j < stop; j++) {
-        #else
+#else
         for (unsigned j = i + 1; j < h; j++) {
-        #endif
+#endif
             uint8_t mask = _if_zero_then_0xff( pivots[i] );
             pivots[i] ^= mask & pivots[j];
 
@@ -776,12 +771,12 @@ unsigned _gf16mat_sol_64x64_avx2( uint8_t *mat, __m256i *vec) {
 
         __m256i rowi = _mm256_load_si256( (__m256i *)(mat + i * w_byte) );
 
-        #if defined( _GE_CADD_EARLY_STOP_ )
-        unsigned stop = (i + 16 < h) ? i + 16 : h;
+#if defined( _GE_CONST_TIME_CADD_EARLY_STOP_ )   // defined in config.h
+        unsigned stop = (i + _GE_EARLY_STOP_STEPS_GF16_ < h) ? i + _GE_EARLY_STOP_STEPS_GF16_ : h;
         for (unsigned j = i + 1; j < stop; j++) {
-        #else
+#else
         for (unsigned j = i + 1; j < h; j++) {
-        #endif
+#endif
             uint8_t mask = _if_zero_then_0xff( pivots[i] );
             pivots[i] ^= mask & pivots[j];
             __m256i mask_zero = _mm256_set1_epi8( mask );
@@ -919,12 +914,12 @@ unsigned _gf256mat_gauss_elim_row_echelon_avx2( uint8_t *mat, unsigned h, unsign
 
         uint8_t *mi = mat + i * w;
 
-        #if defined( _GE_CADD_EARLY_STOP_ )
-        unsigned stop = (i + 8 < h) ? i + 8 : h;
+#if defined( _GE_CONST_TIME_CADD_EARLY_STOP_ )   // defined in config.h
+        unsigned stop = (i + _GE_EARLY_STOP_STEPS_GF256_ < h) ? i + _GE_EARLY_STOP_STEPS_GF256_ : h;
         for (unsigned j = i + 1; j < stop; j++) {
-        #else
+#else
         for (unsigned j = i + 1; j < h; j++) {
-        #endif
+#endif
             __m128i piv_i   = _mm_load_si128( (__m128i *)( mi + i_d16 * 16 ) );
             __m128i is_zero = _mm_cmpeq_epi8( piv_i, mask_0 );
             __m128i add_mask = _mm_shuffle_epi8( is_zero, _mm_set1_epi8(i_r16) );

--- a/src/config.h
+++ b/src/config.h
@@ -8,6 +8,17 @@
  *   params.h contains other options.
  */
 
+
+//
+// This macro set the max steps for conditional row-swaps in the constant time
+// Gaussian Elimination algorithm.
+// Default value : OFF
+//
+//#define _GE_CONST_TIME_CADD_EARLY_STOP_
+#define _GE_EARLY_STOP_STEPS_GF16_    16
+#define _GE_EARLY_STOP_STEPS_GF256_   8
+
+
 //
 // The following macros choose optimizations for basic linear algebra functions.
 // It is currently defined from the makefile

--- a/src/gfni/blas_matrix_avx2_gfni.c
+++ b/src/gfni/blas_matrix_avx2_gfni.c
@@ -23,11 +23,6 @@
 
 #include "params.h"  // for macro _USE_GF16
 
-
-#define _GE_CADD_EARLY_STOP_
-
-
-
 ////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////  matrix-vector multiplication, GF( 256 ) ///////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////
@@ -279,12 +274,12 @@ unsigned _gf256mat_gauss_elim_row_echelon_avx2_gfni( uint8_t *mat, unsigned h, u
 
         uint8_t *mi = mat + i * w;
 
-        #if defined( _GE_CADD_EARLY_STOP_ )
-        unsigned stop = (i + 8 < h) ? i + 8 : h;
+#if defined( _GE_CONST_TIME_CADD_EARLY_STOP_ )   // defined in config.h
+        unsigned stop = (i + _GE_EARLY_STOP_STEPS_GF256_ < h) ? i + _GE_EARLY_STOP_STEPS_GF256_ : h;
         for (unsigned j = i + 1; j < stop; j++) {
-        #else
+#else
         for (unsigned j = i + 1; j < h; j++) {
-        #endif
+#endif
             __m128i piv_i   = _mm_load_si128( (__m128i *)( mi + i_d16 * 16 ) );
             __m128i is_zero = _mm_cmpeq_epi8( piv_i, mask_0 );
             __m128i add_mask = _mm_shuffle_epi8( is_zero, _mm_set1_epi8(i_r16) );

--- a/src/neon/blas_matrix_neon.c
+++ b/src/neon/blas_matrix_neon.c
@@ -14,12 +14,7 @@
 
 #include "blas_matrix_neon.h"
 
-
 #include "string.h"
-
-
-#define _GE_CADD_EARLY_STOP_
-
 
 //////////// specialized functions  /////////////////////
 
@@ -456,12 +451,12 @@ unsigned gf16mat_gauss_elim_row_echolen( uint8_t *mat, unsigned h, unsigned w_by
             pivots[j] = gf16v_get_ele( mat + w_2 * j, idx );
         }
 
-        #if defined( _GE_CADD_EARLY_STOP_ )
-        unsigned stop = (i + 16 < h) ? i + 16 : h;
+#if defined( _GE_CONST_TIME_CADD_EARLY_STOP_ )   // defined in config.h
+        unsigned stop = (i + _GE_EARLY_STOP_STEPS_GF16_ < h) ? i + _GE_EARLY_STOP_STEPS_GF16_ : h;
         for (unsigned j = i + 1; j < stop; j++) {
-        #else
+#else
         for (unsigned j = i + 1; j < h; j++) {
-        #endif
+#endif
             uint8_t m8 = !gf16_is_nonzero( pivots[i] );
             m8 = -m8;
             uint8x16_t m128 = vdupq_n_u8( m8 );
@@ -1031,12 +1026,12 @@ unsigned gf256mat_gauss_elim_row_echolen( uint8_t *mat, unsigned h, unsigned w, 
             pivots[j] = mat[ w * j + idx ];
         }
 
-        #if defined( _GE_CADD_EARLY_STOP_ )
-        unsigned stop = (i + 8 < h) ? i + 8 : h;
+#if defined( _GE_CONST_TIME_CADD_EARLY_STOP_ )   // defined in config.h
+        unsigned stop = (i + _GE_EARLY_STOP_STEPS_GF256_ < h) ? i + _GE_EARLY_STOP_STEPS_GF256_ : h;
         for (unsigned j = i + 1; j < stop; j++) {
-        #else
+#else
         for (unsigned j = i + 1; j < h; j++) {
-        #endif
+#endif
             uint8_t m8 = !gf256_is_nonzero( pivots[i] );
             m8 = -m8;
             pivots[i] ^= m8 & pivots[j];

--- a/src/ref/blas_matrix_ref.c
+++ b/src/ref/blas_matrix_ref.c
@@ -7,11 +7,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "config.h"   /// for the macro: _GE_CONST_TIME_CADD_EARLY_STOP_
+
 #include "params.h"   /// for macro  _USE_GF16
-
-
-#define _GE_CADD_EARLY_STOP_
-
 
 /// This implementation depends on these vector functions :
 ///   0.  gf16v_mul_scalar
@@ -92,12 +90,12 @@ unsigned gf16mat_gauss_elim_row_echolen( uint8_t *mat, unsigned h, unsigned w_by
         uint8_t *ai = mat + w_byte * i;
         //unsigned i_start = i-(i&(_BLAS_UNIT_LEN_-1));
         unsigned i_start = i >> 1;
-        #if defined( _GE_CADD_EARLY_STOP_ )
-        unsigned stop = (i + 16 < h) ? i + 16 : h;
+#if defined( _GE_CONST_TIME_CADD_EARLY_STOP_ )   // defined in config.h
+        unsigned stop = (i + _GE_EARLY_STOP_STEPS_GF16_ < h) ? i + _GE_EARLY_STOP_STEPS_GF16_ : h;
         for (unsigned j = i + 1; j < stop; j++) {
-        #else
+#else
         for (unsigned j = i + 1; j < h; j++) {
-        #endif
+#endif
             uint8_t *aj = mat + w_byte * j;
             gf256v_conditional_add( ai + i_start, !gf16_is_nonzero(gf16v_get_ele(ai, i)), aj + i_start, w_byte - i_start );
         }
@@ -203,12 +201,12 @@ unsigned gf256mat_gauss_elim_row_echolen( uint8_t *mat, unsigned h, unsigned w )
         //unsigned i_start = i-(i&(_BLAS_UNIT_LEN_-1));
         unsigned i_start = i;
 
-        #if defined( _GE_CADD_EARLY_STOP_ )
-        unsigned stop = (i + 8 < h) ? i + 8 : h;
+#if defined( _GE_CONST_TIME_CADD_EARLY_STOP_ )   // defined in config.h
+        unsigned stop = (i + _GE_EARLY_STOP_STEPS_GF256_ < h) ? i + _GE_EARLY_STOP_STEPS_GF256_ : h;
         for (unsigned j = i + 1; j < stop; j++) {
-        #else
+#else
         for (unsigned j = i + 1; j < h; j++) {
-        #endif
+#endif
             uint8_t *aj = mat + w * j;
             gf256v_conditional_add( ai + i_start, !gf256_is_nonzero(ai[i]), aj + i_start, w - i_start );
         }


### PR DESCRIPTION
This commit set the option of early-stop of conditional swap in const time GE to OFF and move its macro to config.h 

A bit more context (mjk): In https://eprint.iacr.org/2023/059, we propose a trick (see 'Reducing the number of conditional additions' paragraph) to reduce the number of conditional additions by adding a fixed number of rows resulting in a very small chance (~2^-58) to wrongly refusing a system of equations as not being solvable. In the worst case, we wrongly reject a set of vinegars and sample new ones. 
Unfortunately, this trick makes formal verification of the implementation much harder (or impossible rather, because there is a small chance it is incorrect). We, hence, disable it by default now. 