### PR TITLE
Refine AVX2 matrix vector multiplication

### DIFF
--- a/src/avx2/blas_avx2.h
+++ b/src/avx2/blas_avx2.h
@@ -88,14 +88,23 @@ static inline
 void linearmap_8x8_ymm( uint8_t *a, __m256i ml, __m256i mh, __m256i mask, unsigned _num_byte ) {
     unsigned n_32 = _num_byte >> 5;
     unsigned rem = _num_byte & 31;
+    if ( rem ) {
+        if ( n_32 ) {
+            __m256i indices = _mm256_set_epi32( 0x1f1e1d1c, 0x1b1a1918, 0x17161514, 0x13121110, 0x0f0e0d0c, 0x0b0a0908, 0x07060504, 0x03020100 );
+            __m256i meff = _mm256_cmpgt_epi8( _mm256_set1_epi8(rem), indices );
+            __m256i inp = _mm256_loadu_si256((__m256i *)a);
+            __m256i bb = (linear_transform_8x8_256b( ml, mh, inp, mask )&meff) ^ _mm256_andnot_si256(meff,inp);
+            _mm256_storeu_si256( (__m256i *)a, bb );
+        } else {
+            linearmap_8x8_sse( a, _mm256_castsi256_si128(ml), _mm256_castsi256_si128(mh), _mm256_castsi256_si128(mask), rem );
+        }
+        a += rem;
+    }
     while (n_32--) {
         __m256i inp = _mm256_loadu_si256( (__m256i *)a );
         __m256i r0 = linear_transform_8x8_256b( ml, mh, inp, mask );
         _mm256_storeu_si256( (__m256i *)a, r0 );
         a += 32;
-    }
-    if ( rem ) {
-        linearmap_8x8_sse( a, _mm256_castsi256_si128(ml), _mm256_castsi256_si128(mh), _mm256_castsi256_si128(mask), rem );
     }
 }
 
@@ -104,6 +113,20 @@ static inline
 void linearmap_8x8_accu_ymm( uint8_t *accu_c, const uint8_t *a,  __m256i ml, __m256i mh, __m256i mask, unsigned _num_byte ) {
     unsigned n_32 = _num_byte >> 5;
     unsigned rem = _num_byte & 31;
+    if ( rem ) {
+        if (n_32 ) {
+            __m256i indices = _mm256_set_epi32( 0x1f1e1d1c, 0x1b1a1918, 0x17161514, 0x13121110, 0x0f0e0d0c, 0x0b0a0908, 0x07060504, 0x03020100 );
+            __m256i meff = _mm256_cmpgt_epi8( _mm256_set1_epi8(rem), indices );
+            __m256i inp = _mm256_loadu_si256((__m256i *)a);
+            __m256i out = _mm256_loadu_si256( (__m256i *)accu_c );
+            __m256i r0 = out ^ (linear_transform_8x8_256b( ml, mh, inp, mask )&meff);
+            _mm256_storeu_si256( (__m256i *)accu_c, r0 );
+        } else {
+            linearmap_8x8_accu_sse( accu_c, a, _mm256_castsi256_si128(ml), _mm256_castsi256_si128(mh), _mm256_castsi256_si128(mask), rem );
+        }
+        a += rem;
+        accu_c += rem;
+    }
     while (n_32--) {
         __m256i inp = _mm256_loadu_si256( (__m256i *)a );
         __m256i out = _mm256_loadu_si256( (__m256i *)accu_c );
@@ -111,9 +134,6 @@ void linearmap_8x8_accu_ymm( uint8_t *accu_c, const uint8_t *a,  __m256i ml, __m
         _mm256_storeu_si256( (__m256i *)accu_c, r0 );
         a += 32;
         accu_c += 32;
-    }
-    if ( rem ) {
-        linearmap_8x8_accu_sse( accu_c, a, _mm256_castsi256_si128(ml), _mm256_castsi256_si128(mh), _mm256_castsi256_si128(mask), rem );
     }
 }
 
@@ -125,14 +145,27 @@ void linearmap_8x8_accu_ymm( uint8_t *accu_c, const uint8_t *a,  __m256i ml, __m
 
 static inline
 void gf256v_add_avx2( uint8_t *accu_b, const uint8_t *a, unsigned _num_byte ) {
-    while ( _num_byte >= 32 ) {
+    if ( _num_byte & 31 ) {
+        unsigned rem = _num_byte & 31;
+        if ( _num_byte < 32 ) {
+            gf256v_add_sse( accu_b, a, _num_byte );
+        } else {
+            __m256i indices = _mm256_set_epi32( 0x1f1e1d1c, 0x1b1a1918, 0x17161514, 0x13121110, 0x0f0e0d0c, 0x0b0a0908, 0x07060504, 0x03020100 );
+            __m256i mask = _mm256_cmpgt_epi8( _mm256_set1_epi8(rem), indices );
+            __m256i aa = _mm256_loadu_si256((__m256i *)a);
+            __m256i ab = _mm256_loadu_si256((__m256i *)accu_b);
+            __m256i bb = ab ^ (aa&mask);
+            _mm256_storeu_si256( (__m256i *)accu_b, bb );
+        }
+        a += rem;
+        accu_b += rem;
+        _num_byte -= rem;
+    }
+    while ( _num_byte ) {
         _mm256_storeu_si256( (__m256i *)accu_b, _mm256_loadu_si256((__m256i *)a) ^ _mm256_loadu_si256((__m256i *)accu_b) );
         accu_b += 32;
         a += 32;
         _num_byte -= 32;
-    }
-    if (_num_byte) {
-        gf256v_add_sse( accu_b, a, _num_byte );
     }
 }
 

--- a/src/avx2/blas_matrix_avx2.c
+++ b/src/avx2/blas_matrix_avx2.c
@@ -59,176 +59,91 @@ void gf16mat_prod_multab_64x_avx2( uint8_t *c, const uint8_t *matA, unsigned n_e
     _mm256_storeu_si256( (__m256i *)c, r0 ^ r1 );
 }
 
-static void gf16mat_prod_multab_32x32_avx2( uint8_t *c, const uint8_t *matA, const __m256i *multab_b ) {
-    __m256i mask_f = _mm256_set1_epi8(0xf);
-    __m256i ma01 = _mm256_loadu_si256((const __m256i *) (matA) ); // 2 rows
-    __m256i ma23 = _mm256_loadu_si256((const __m256i *) (matA + 32) ); // 2 rows
-    __m256i ma45 = _mm256_loadu_si256((const __m256i *) (matA + 64) ); // 2 rows
-    __m256i ma67 = _mm256_loadu_si256((const __m256i *) (matA + 96) ); // 2 rows
-    __m256i mb01 = _mm256_permute2x128_si256( multab_b[0], multab_b[1], 0x20 );
-    __m256i mb23 = _mm256_permute2x128_si256( multab_b[2], multab_b[3], 0x20 );
-    __m256i mb45 = _mm256_permute2x128_si256( multab_b[4], multab_b[5], 0x20 );
-    __m256i mb67 = _mm256_permute2x128_si256( multab_b[6], multab_b[7], 0x20 );
-    __m256i r = _mm256_shuffle_epi8( mb01, ma01 & mask_f )^_mm256_shuffle_epi8( _mm256_slli_epi16(mb01, 4), _mm256_srli_epi16(ma01, 4)&mask_f );
-    r ^= _mm256_shuffle_epi8( mb23, ma23 & mask_f )^_mm256_shuffle_epi8( _mm256_slli_epi16(mb23, 4), _mm256_srli_epi16(ma23, 4)&mask_f );
-    r ^= _mm256_shuffle_epi8( mb45, ma45 & mask_f )^_mm256_shuffle_epi8( _mm256_slli_epi16(mb45, 4), _mm256_srli_epi16(ma45, 4)&mask_f );
-    r ^= _mm256_shuffle_epi8( mb67, ma67 & mask_f )^_mm256_shuffle_epi8( _mm256_slli_epi16(mb67, 4), _mm256_srli_epi16(ma67, 4)&mask_f );
-    for (int i = 8; i < 32; i += 8) {
-        multab_b += 8;
-        matA += 128;
-
-        ma01 = _mm256_loadu_si256((const __m256i *) (matA) ); // 2 rows
-        ma23 = _mm256_loadu_si256((const __m256i *) (matA + 32) ); // 2 rows
-        ma45 = _mm256_loadu_si256((const __m256i *) (matA + 64) ); // 2 rows
-        ma67 = _mm256_loadu_si256((const __m256i *) (matA + 96) ); // 2 rows
-        mb01 = _mm256_permute2x128_si256( multab_b[0], multab_b[1], 0x20 );
-        mb23 = _mm256_permute2x128_si256( multab_b[2], multab_b[3], 0x20 );
-        mb45 = _mm256_permute2x128_si256( multab_b[4], multab_b[5], 0x20 );
-        mb67 = _mm256_permute2x128_si256( multab_b[6], multab_b[7], 0x20 );
-        r ^= _mm256_shuffle_epi8( mb01, ma01 & mask_f )^_mm256_shuffle_epi8( _mm256_slli_epi16(mb01, 4), _mm256_srli_epi16(ma01, 4)&mask_f );
-        r ^= _mm256_shuffle_epi8( mb23, ma23 & mask_f )^_mm256_shuffle_epi8( _mm256_slli_epi16(mb23, 4), _mm256_srli_epi16(ma23, 4)&mask_f );
-        r ^= _mm256_shuffle_epi8( mb45, ma45 & mask_f )^_mm256_shuffle_epi8( _mm256_slli_epi16(mb45, 4), _mm256_srli_epi16(ma45, 4)&mask_f );
-        r ^= _mm256_shuffle_epi8( mb67, ma67 & mask_f )^_mm256_shuffle_epi8( _mm256_slli_epi16(mb67, 4), _mm256_srli_epi16(ma67, 4)&mask_f );
-    }
-
-    __m128i r0 = _mm256_castsi256_si128( r );
-    __m128i r1 = _mm256_extractf128_si256( r, 1 );
-    _mm_storeu_si128( (__m128i *)c, r0 ^ r1 );
-}
-
-static void gf16mat_prod_multab_16x16_avx2( uint8_t *c, const uint8_t *matA, const __m256i *multab_b ) {
+#include "stdio.h"
+// this function is slow. It's for complete of the blas lib and sould not be reached in the UOV implementation.
+static inline
+void gf16mat_remaining_madd_avx2( uint8_t *dest, const uint8_t *mat, unsigned mat_vec_byte, unsigned blk_vec_byte, const __m256i *multab_vec_ele, unsigned n_vec_ele ) {
+    unsigned rem_byte = blk_vec_byte & 31;
     __m256i mask_f = _mm256_set1_epi8(0xf);
 
-    __m256i ma0123 = _mm256_loadu_si256((const __m256i *) (matA) );   // 4 rows
-    __m256i ma4567 = _mm256_loadu_si256((const __m256i *) (matA + 32) ); // 4 rows
-    __m256i mb02 = _mm256_permute2x128_si256( multab_b[0], multab_b[2], 0x20 );
-    __m256i mb13 = _mm256_permute2x128_si256( multab_b[1], multab_b[3], 0x20 );
-    __m256i mb46 = _mm256_permute2x128_si256( multab_b[4], multab_b[6], 0x20 );
-    __m256i mb57 = _mm256_permute2x128_si256( multab_b[5], multab_b[7], 0x20 );
-    __m256i ma0123l = ma0123 & mask_f;
-    __m256i ma0123h = _mm256_srli_epi16(ma0123, 4)&mask_f;
-    __m256i ma4567l = ma4567 & mask_f;
-    __m256i ma4567h = _mm256_srli_epi16(ma4567, 4)&mask_f;
-    __m256i ma02 = _mm256_unpacklo_epi64(ma0123l, ma0123h);
-    __m256i ma13 = _mm256_unpackhi_epi64(ma0123l, ma0123h);
-    __m256i ma46 = _mm256_unpacklo_epi64(ma4567l, ma4567h);
-    __m256i ma57 = _mm256_unpackhi_epi64(ma4567l, ma4567h);
-    __m256i r = _mm256_shuffle_epi8(mb02, ma02)^_mm256_shuffle_epi8(mb13, ma13)^_mm256_shuffle_epi8(mb46, ma46)^_mm256_shuffle_epi8(mb57, ma57);
+    __m256i dd = _load_ymm(dest,rem_byte);
 
-    __m256i ma89ab = _mm256_loadu_si256((const __m256i *) (matA + 64) ); // 4 rows
-    __m256i macdef = _mm256_loadu_si256((const __m256i *) (matA + 96) ); // 4 rows
-    __m256i mb8a = _mm256_permute2x128_si256( multab_b[8], multab_b[10], 0x20 );
-    __m256i mb9b = _mm256_permute2x128_si256( multab_b[9], multab_b[11], 0x20 );
-    __m256i mbce = _mm256_permute2x128_si256( multab_b[12], multab_b[14], 0x20 );
-    __m256i mbdf = _mm256_permute2x128_si256( multab_b[13], multab_b[15], 0x20 );
-    __m256i ma89abl = ma89ab & mask_f;
-    __m256i ma89abh = _mm256_srli_epi16(ma89ab, 4)&mask_f;
-    __m256i macdefl = macdef & mask_f;
-    __m256i macdefh = _mm256_srli_epi16(macdef, 4)&mask_f;
-    __m256i ma8a = _mm256_unpacklo_epi64(ma89abl, ma89abh);
-    __m256i ma9b = _mm256_unpackhi_epi64(ma89abl, ma89abh);
-    __m256i mace = _mm256_unpacklo_epi64(macdefl, macdefh);
-    __m256i madf = _mm256_unpackhi_epi64(macdefl, macdefh);
-    r ^= _mm256_shuffle_epi8(mb8a, ma8a)^_mm256_shuffle_epi8(mb9b, ma9b)^_mm256_shuffle_epi8(mbce, mace)^_mm256_shuffle_epi8(mbdf, madf);
-
-    __m128i rr = _mm256_castsi256_si128( r ) ^ _mm256_extractf128_si256( r, 1 );
-    __m128i rr2 = rr ^ _mm_srli_si128( _mm_slli_epi16(rr, 4), 8 );
-
-    uint8_t temp[16] __attribute__((aligned(16)));
-    _mm_store_si128( (__m128i *)temp, rr2 );
-    for (int i = 0; i < 8; i++) {
-        c[i] = temp[i];
+    for (unsigned i = 0; i < n_vec_ele - 1; i++ ) {
+        __m256i tab_l = multab_vec_ele[0];
+        __m256i tab_h = _mm256_slli_epi16(tab_l, 4);;
+        multab_vec_ele ++;
+        __m256i mi = _load_ymm( mat , rem_byte );
+        dd ^= linear_transform_8x8_256b( tab_l , tab_h , mi , mask_f );
+        mat += mat_vec_byte;
     }
+    _store_ymm( dest, rem_byte , dd );
 }
-
-
 
 static inline
-void gf16mat_blockmat_madd_avx2( __m256i *dest, const uint8_t *org_mat, unsigned mat_vec_byte, unsigned blk_st_idx, unsigned blk_vec_byte,
+void gf16mat_blockmat_madd_avx2( __m256i *dest, const uint8_t *org_mat, unsigned mat_vec_byte, unsigned blk_st_idx, unsigned blk_vec_ymm,
                                  const __m256i *multab_vec_ele, unsigned n_vec_ele ) {
-    unsigned n_full_ymm = blk_vec_byte >> 5;
-    unsigned n_rem_byte = blk_vec_byte & 31;
     __m256i mask_f = _mm256_set1_epi8(0xf);
 
     org_mat += blk_st_idx;
-    if (!n_rem_byte) {
-        for (unsigned i = 0; i < n_vec_ele; i++ ) {
-            __m256i tab_l = multab_vec_ele[0];
-            __m256i tab_h = _mm256_slli_epi16(tab_l, 4);;
-            multab_vec_ele ++;
+    for (unsigned i = 0; i < n_vec_ele; i++ ) {
+        __m256i tab_l = multab_vec_ele[0];
+        __m256i tab_h = _mm256_slli_epi16(tab_l, 4);;
+        multab_vec_ele ++;
 
-            for (unsigned j = 0; j < n_full_ymm; j++) {
-                __m256i mj = _mm256_loadu_si256( (__m256i *)(org_mat + j * 32) );
-                dest[j] ^= linear_transform_8x8_256b( tab_l, tab_h, mj, mask_f );
-            }
-            org_mat += mat_vec_byte;
+        for (unsigned j = 0; j < blk_vec_ymm; j++) {
+            __m256i mj = _mm256_loadu_si256( (__m256i *)(org_mat + j * 32) );
+            dest[j] ^= linear_transform_8x8_256b( tab_l, tab_h, mj, mask_f );
         }
-    } else {
-        for (unsigned i = 0; i < n_vec_ele - 1; i++ ) {
-            __m256i tab_l = multab_vec_ele[0];
-            __m256i tab_h = _mm256_slli_epi16(tab_l, 4);;
-            multab_vec_ele ++;
-            for (unsigned j = 0; j < n_full_ymm + 1; j++) {
-                __m256i mj = _mm256_loadu_si256( (__m256i *)(org_mat + j * 32) );
-                dest[j] ^= linear_transform_8x8_256b( tab_l, tab_h, mj, mask_f );
-            }
-            org_mat += mat_vec_byte;
-        }{ // i = n_vec_ele-1
-            __m256i tab_l = multab_vec_ele[0];
-            __m256i tab_h = _mm256_slli_epi16(tab_l, 4);;
-            multab_vec_ele ++;
-            for (unsigned j = 0; j < n_full_ymm; j++) {
-                __m256i mj = _mm256_loadu_si256( (__m256i *)(org_mat + j * 32) );
-                dest[j] ^= linear_transform_8x8_256b( tab_l, tab_h, mj, mask_f );
-            } //if( n_rem_byte )
-            {
-                // j = n_full_ymm;
-                __m256i mj = _load_ymm( org_mat + (n_full_ymm * 32), n_rem_byte );
-                dest[n_full_ymm] ^= linear_transform_8x8_256b( tab_l, tab_h, mj, mask_f );
-            }
-        }
+        org_mat += mat_vec_byte;
     }
 }
 
+#include "stdlib.h"
+
+#define _MAX_YMM_BUF_  (8)
 
 void gf16mat_prod_multab_avx2( uint8_t *c, const uint8_t *matA, unsigned matA_vec_byte, unsigned matA_n_vec, const uint8_t *multab_b ) {
     if ((32 == matA_vec_byte)) {
         gf16mat_prod_multab_64x_avx2(c, matA, matA_n_vec, (const __m256i *)multab_b);
         return;
     }
-    if ((16 == matA_vec_byte) && (32 == matA_n_vec)) {
-        gf16mat_prod_multab_32x32_avx2(c, matA, (const __m256i *)multab_b);
-        return;
-    }
-    if ((8 == matA_vec_byte) && (16 == matA_n_vec)) {
-        gf16mat_prod_multab_16x16_avx2(c, matA, (const __m256i *)multab_b);
-        return;
-    }
+
+    printf("here: vec_len: %d , n_vec: %d\n", matA_vec_byte,matA_n_vec);
 
     const __m256i *multabs = (const __m256i *)multab_b;
     gf256v_set_zero( c, matA_vec_byte );
 
-    __m256i blockmat_vec[8];
+    __m256i blockmat_vec[_MAX_YMM_BUF_];
 
     while (matA_n_vec) {
-
-        unsigned n_ele = (matA_n_vec >= 32) ? 32 : matA_n_vec;
+        unsigned n_ele = (matA_n_vec >= 96) ? 96 : matA_n_vec;
         unsigned vec_len_to_go = matA_vec_byte;
+        if ( vec_len_to_go&31 ) {
+            printf("here");
+            gf16mat_remaining_madd_avx2( c, matA, matA_vec_byte, vec_len_to_go&31, multabs, n_ele );
+            vec_len_to_go -= (vec_len_to_go&31);
+        }
+    printf("here: vec_len_to_go: %d, vec_len: %d , n_vec: %d\n", vec_len_to_go , matA_vec_byte,matA_n_vec);
+
         while ( vec_len_to_go ) {
-            unsigned block_len = (vec_len_to_go >= 8 * 32) ? 8 * 32 : vec_len_to_go;
+            unsigned block_len = (vec_len_to_go >= _MAX_YMM_BUF_ * 32) ? _MAX_YMM_BUF_ * 32 : vec_len_to_go;
             unsigned block_st_idx = matA_vec_byte - vec_len_to_go;
 
             loadu_ymm( blockmat_vec, c + block_st_idx, block_len );
-            gf16mat_blockmat_madd_avx2( blockmat_vec, matA, matA_vec_byte, block_st_idx, block_len, multabs, n_ele );
+            gf16mat_blockmat_madd_avx2( blockmat_vec, matA, matA_vec_byte, block_st_idx, block_len>>5, multabs, n_ele );
             storeu_ymm( c + block_st_idx, block_len, blockmat_vec );
 
             vec_len_to_go -= block_len;
+    printf("inner: vec_len_to_go: %d, vec_len: %d , n_vec: %d\n", vec_len_to_go , matA_vec_byte,matA_n_vec);
         }
+    printf("here: vec_len_to_go: %d, vec_len: %d , n_vec: %d\n", vec_len_to_go , matA_vec_byte,matA_n_vec);
 
         matA_n_vec -= n_ele;
         multabs += n_ele;
         matA += n_ele * matA_vec_byte;
     }
+    printf("here: vec_len: %d , n_vec: %d\n", matA_vec_byte,matA_n_vec);
+    //exit(-1);
 }
 
 
@@ -256,42 +171,11 @@ static void gf16mat_prod_64x_avx2( uint8_t *c, const uint8_t *matA, unsigned n_e
 }
 
 
-static void gf16mat_prod_32x32_avx2( uint8_t *c, const uint8_t *matA, const uint8_t *b ) {
-    __m256i multabs[32];
-    __m128i x0 = _mm_loadu_si128((const __m128i *)b);
-    xmmx2_t xx = gf16v_split_16to32_sse2( x0 );
-    gf16v_generate_multab_16_avx2( multabs, xx.v0, 16 );
-    gf16v_generate_multab_16_avx2( multabs + 16, xx.v1, 16 );
-
-    gf16mat_prod_multab_32x32_avx2( c, matA, multabs );
-}
-
-static void gf16mat_prod_16x16_avx2( uint8_t *c, const uint8_t *matA, const uint8_t *b ) {
-    __m256i multabs[16];
-    uint8_t temp[16] __attribute__((aligned(16)));
-    for (int i = 0; i < 8; i++) {
-        temp[i] = b[i];
-    }
-    __m128i x0 = _mm_load_si128((const __m128i *)temp);
-    xmmx2_t xx = gf16v_split_16to32_sse2( x0 );
-    gf16v_generate_multab_16_avx2( multabs, xx.v0, 16 );
-
-    gf16mat_prod_multab_16x16_avx2( c, matA, multabs );
-}
-
-
 
 void gf16mat_prod_avx2( uint8_t *c, const uint8_t *matA, unsigned matA_vec_byte, unsigned matA_n_vec, const uint8_t *b ) {
     if ((32 == matA_vec_byte)) {
+        printf("case 1 called.\n");
         gf16mat_prod_64x_avx2(c, matA, matA_n_vec, b);
-        return;
-    }
-    if ((16 == matA_vec_byte) && (32 == matA_n_vec)) {
-        gf16mat_prod_32x32_avx2(c, matA, b);
-        return;
-    }
-    if ((8 == matA_vec_byte) && (16 == matA_n_vec)) {
-        gf16mat_prod_16x16_avx2(c, matA, b);
         return;
     }
 

--- a/src/avx2/blas_matrix_avx2.c
+++ b/src/avx2/blas_matrix_avx2.c
@@ -19,7 +19,7 @@
 
 #include "string.h"
 
-#include "params.h"  // for macro _USE_GF16
+#include "params.h"  // for macro _USE_GF16 and _V
 
 ////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////  matrix-vector multiplication, GF( 16 ) ////////////////////
@@ -59,18 +59,64 @@ void gf16mat_prod_multab_64x_avx2( uint8_t *c, const uint8_t *matA, unsigned n_e
     _mm256_storeu_si256( (__m256i *)c, r0 ^ r1 );
 }
 
-#include "stdio.h"
-// this function is slow. It's for complete of the blas lib and sould not be reached in the UOV implementation.
 static inline
-void gf16mat_remaining_madd_avx2( uint8_t *dest, const uint8_t *mat, unsigned mat_vec_byte, unsigned blk_vec_byte, const __m256i *multab_vec_ele, unsigned n_vec_ele ) {
-    unsigned rem_byte = blk_vec_byte & 31;
+void gf16mat_prod_multab_96x_avx2( uint8_t *c, const uint8_t *matA, unsigned n_ele, const __m256i *multab_b ) {
     __m256i mask_f = _mm256_set1_epi8(0xf);
+    __m256i a0, a1;
+    __m256i r0 = _mm256_setzero_si256();
+    __m256i r1 = _mm256_setzero_si256();
+    __m128i aa0, aa1;
+    __m128i rr0 = _mm_setzero_si128();
+    __m128i rr1 = _mm_setzero_si128();
 
+    if ( n_ele & 1 ) {
+        a0 = _mm256_loadu_si256((const __m256i *) (matA) );
+        aa0 = _mm_loadu_si128((const __m128i *) (matA+32) );
+        __m256i tab0_l = multab_b[0];
+        __m256i tab0_h = _mm256_slli_epi16(tab0_l,4);
+        r0  ^= _mm256_shuffle_epi8( tab0_l, a0 & mask_f )
+              ^_mm256_shuffle_epi8( tab0_h, _mm256_srli_epi16(a0, 4)&mask_f );
+        rr0 ^= _mm_shuffle_epi8( _mm256_castsi256_si128(tab0_l), aa0 & _mm256_castsi256_si128(mask_f) )
+              ^_mm_shuffle_epi8( _mm256_castsi256_si128(tab0_h), _mm_srli_epi16(aa0, 4)&_mm256_castsi256_si128(mask_f) );
+        matA += 48;
+        multab_b += 1;
+        n_ele -= 1;
+    }
+    while ( n_ele ) {
+        a0  = _mm256_loadu_si256((const __m256i *) (matA) );
+        aa0 = _mm_loadu_si128((const __m128i *) (matA+32) );
+        a1  = _mm256_loadu_si256((const __m256i *) (matA + 48) );
+        aa1 = _mm_loadu_si128((const __m128i *) (matA+80) );
+        __m256i tab0_l = multab_b[0];
+        __m256i tab0_h = _mm256_slli_epi16(tab0_l,4);
+        __m256i tab1_l = multab_b[1];
+        __m256i tab1_h = _mm256_slli_epi16(tab1_l,4);
+        r0  ^= _mm256_shuffle_epi8( tab0_l, a0 & mask_f )
+              ^_mm256_shuffle_epi8( tab0_h, _mm256_srli_epi16(a0, 4)&mask_f );
+        rr0 ^= _mm_shuffle_epi8( _mm256_castsi256_si128(tab0_l), aa0 & _mm256_castsi256_si128(mask_f) )
+              ^_mm_shuffle_epi8( _mm256_castsi256_si128(tab0_h), _mm_srli_epi16(aa0, 4)&_mm256_castsi256_si128(mask_f) );
+        r1  ^= _mm256_shuffle_epi8( tab1_l, a1 & mask_f )
+              ^_mm256_shuffle_epi8( tab1_h, _mm256_srli_epi16(a1, 4)&mask_f );
+        rr1 ^= _mm_shuffle_epi8( _mm256_castsi256_si128(tab1_l), aa1 & _mm256_castsi256_si128(mask_f) )
+              ^_mm_shuffle_epi8( _mm256_castsi256_si128(tab1_h), _mm_srli_epi16(aa1, 4)&_mm256_castsi256_si128(mask_f) );
+        matA += 96;
+        multab_b += 2;
+        n_ele -= 2;
+    }
+    _mm256_storeu_si256( (__m256i *)c, r0 ^ r1 );
+    _mm_storeu_si128( (__m128i *)(c+32), rr0 ^ rr1 );
+}
+
+// this function is slow. It's for the completeness of blas libs and sould not be reached in the UOV implementation.
+static inline
+void gf16mat_remaining_madd_avx2( uint8_t *dest, const uint8_t *mat, unsigned mat_vec_byte, unsigned rem_byte,
+                                  const __m256i *multab_vec_ele, unsigned n_vec_ele ) {
+    __m256i mask_f = _mm256_set1_epi8(0xf);
     __m256i dd = _load_ymm(dest,rem_byte);
 
-    for (unsigned i = 0; i < n_vec_ele - 1; i++ ) {
+    for (unsigned i = 0; i < n_vec_ele; i++ ) {
         __m256i tab_l = multab_vec_ele[0];
-        __m256i tab_h = _mm256_slli_epi16(tab_l, 4);;
+        __m256i tab_h = _mm256_slli_epi16(tab_l, 4);
         multab_vec_ele ++;
         __m256i mi = _load_ymm( mat , rem_byte );
         dd ^= linear_transform_8x8_256b( tab_l , tab_h , mi , mask_f );
@@ -87,7 +133,7 @@ void gf16mat_blockmat_madd_avx2( __m256i *dest, const uint8_t *org_mat, unsigned
     org_mat += blk_st_idx;
     for (unsigned i = 0; i < n_vec_ele; i++ ) {
         __m256i tab_l = multab_vec_ele[0];
-        __m256i tab_h = _mm256_slli_epi16(tab_l, 4);;
+        __m256i tab_h = _mm256_slli_epi16(tab_l, 4);
         multab_vec_ele ++;
 
         for (unsigned j = 0; j < blk_vec_ymm; j++) {
@@ -98,35 +144,23 @@ void gf16mat_blockmat_madd_avx2( __m256i *dest, const uint8_t *org_mat, unsigned
     }
 }
 
-#include "stdlib.h"
+#define _VEC_YMM_BUF_  (8)
 
-#define _MAX_YMM_BUF_  (8)
-
-void gf16mat_prod_multab_avx2( uint8_t *c, const uint8_t *matA, unsigned matA_vec_byte, unsigned matA_n_vec, const uint8_t *multab_b ) {
-    if ((32 == matA_vec_byte)) {
-        gf16mat_prod_multab_64x_avx2(c, matA, matA_n_vec, (const __m256i *)multab_b);
-        return;
-    }
-
-    printf("here: vec_len: %d , n_vec: %d\n", matA_vec_byte,matA_n_vec);
-
+static
+void gf16mat_madd_multab_avx2( uint8_t *c, const uint8_t *matA, unsigned matA_vec_byte, unsigned matA_n_vec, const uint8_t *multab_b ) {
     const __m256i *multabs = (const __m256i *)multab_b;
-    gf256v_set_zero( c, matA_vec_byte );
-
-    __m256i blockmat_vec[_MAX_YMM_BUF_];
-
+    __m256i blockmat_vec[_VEC_YMM_BUF_];
     while (matA_n_vec) {
-        unsigned n_ele = (matA_n_vec >= 96) ? 96 : matA_n_vec;
+        unsigned n_ele = (matA_n_vec >= _V) ? _V : matA_n_vec; // _V = 96 in current param for GF(16)
         unsigned vec_len_to_go = matA_vec_byte;
         if ( vec_len_to_go&31 ) {
-            printf("here");
-            gf16mat_remaining_madd_avx2( c, matA, matA_vec_byte, vec_len_to_go&31, multabs, n_ele );
-            vec_len_to_go -= (vec_len_to_go&31);
+            unsigned rem = vec_len_to_go&31;
+            gf16mat_remaining_madd_avx2( c, matA, matA_vec_byte, rem, multabs, n_ele );
+            vec_len_to_go -= rem;
         }
-    printf("here: vec_len_to_go: %d, vec_len: %d , n_vec: %d\n", vec_len_to_go , matA_vec_byte,matA_n_vec);
 
         while ( vec_len_to_go ) {
-            unsigned block_len = (vec_len_to_go >= _MAX_YMM_BUF_ * 32) ? _MAX_YMM_BUF_ * 32 : vec_len_to_go;
+            unsigned block_len = (vec_len_to_go >= _VEC_YMM_BUF_ * 32) ? _VEC_YMM_BUF_ * 32 : vec_len_to_go;
             unsigned block_st_idx = matA_vec_byte - vec_len_to_go;
 
             loadu_ymm( blockmat_vec, c + block_st_idx, block_len );
@@ -134,75 +168,45 @@ void gf16mat_prod_multab_avx2( uint8_t *c, const uint8_t *matA, unsigned matA_ve
             storeu_ymm( c + block_st_idx, block_len, blockmat_vec );
 
             vec_len_to_go -= block_len;
-    printf("inner: vec_len_to_go: %d, vec_len: %d , n_vec: %d\n", vec_len_to_go , matA_vec_byte,matA_n_vec);
         }
-    printf("here: vec_len_to_go: %d, vec_len: %d , n_vec: %d\n", vec_len_to_go , matA_vec_byte,matA_n_vec);
 
         matA_n_vec -= n_ele;
         multabs += n_ele;
         matA += n_ele * matA_vec_byte;
     }
-    printf("here: vec_len: %d , n_vec: %d\n", matA_vec_byte,matA_n_vec);
-    //exit(-1);
 }
 
+// public functions
 
-
-////////////////////////////////////////////////////////////////////
-
-
-
-
-
-static void gf16mat_prod_64x_avx2( uint8_t *c, const uint8_t *matA, unsigned n_ele, const uint8_t *b ) {
-    __m256i multabs[32];
-    __m256i ci;
-    __m256i r = _mm256_setzero_si256();
-    while ( n_ele ) {
-        unsigned i_ele = (32 <= n_ele) ? 32 : n_ele;
-        _gf16v_generate_multabs_avx2( multabs, b, i_ele );
-        gf16mat_prod_multab_64x_avx2( (uint8_t *)&ci, matA, i_ele, multabs );
-        r ^= ci;
-        n_ele -= i_ele;
-        matA += 32 * i_ele;
-        b += i_ele / 2;
+void gf16mat_prod_multab_avx2( uint8_t *c, const uint8_t *matA, unsigned matA_vec_byte, unsigned matA_n_vec, const uint8_t *multab_b ) {
+    if (32 == matA_vec_byte) {
+        gf16mat_prod_multab_64x_avx2(c, matA, matA_n_vec, (const __m256i *)multab_b);
+    } else if (48 == matA_vec_byte) {
+        gf16mat_prod_multab_96x_avx2(c, matA, matA_n_vec, (const __m256i *)multab_b);
+    } else {
+        gf256v_set_zero(c, matA_vec_byte);
+        gf16mat_madd_multab_avx2(c, matA, matA_vec_byte, matA_n_vec, multab_b);
     }
-    _mm256_storeu_si256((__m256i_u *)c, r );
 }
-
-
 
 void gf16mat_prod_avx2( uint8_t *c, const uint8_t *matA, unsigned matA_vec_byte, unsigned matA_n_vec, const uint8_t *b ) {
-    if ((32 == matA_vec_byte)) {
-        printf("case 1 called.\n");
-        gf16mat_prod_64x_avx2(c, matA, matA_n_vec, b);
-        return;
-    }
-
-    __m256i multabs[32];
-    gf256v_set_zero( c, matA_vec_byte );
-
-    __m256i blockmat_vec[8];
-
-    while (matA_n_vec) {
-        unsigned n_ele = (32 <= matA_n_vec) ? 32 : matA_n_vec;
-        _gf16v_generate_multabs_avx2( multabs, b, n_ele );
-
-        unsigned vec_len_to_go = matA_vec_byte;
-        while ( vec_len_to_go ) {
-            unsigned block_len = (vec_len_to_go >= 8 * 32) ? 8 * 32 : vec_len_to_go;
-            unsigned block_st_idx = matA_vec_byte - vec_len_to_go;
-
-            loadu_ymm( blockmat_vec, c + block_st_idx, block_len );
-            gf16mat_blockmat_madd_avx2( blockmat_vec, matA, matA_vec_byte, block_st_idx, block_len, multabs, n_ele );
-            storeu_ymm( c + block_st_idx, block_len, blockmat_vec );
-
-            vec_len_to_go -= block_len;
+    __m256i multabs[_V]; // _V = 96 in current param for GF(16)
+    if (32 == matA_vec_byte && matA_n_vec <= _V) {
+        _gf16v_generate_multabs_avx2( multabs, b, matA_n_vec );
+        gf16mat_prod_multab_64x_avx2(c, matA, matA_n_vec, multabs);
+    } else if (48 == matA_vec_byte && matA_n_vec <= _V) {
+        _gf16v_generate_multabs_avx2( multabs, b, matA_n_vec );
+        gf16mat_prod_multab_96x_avx2(c, matA, matA_n_vec, multabs);
+    } else {
+        gf256v_set_zero( c, matA_vec_byte );
+        while( matA_n_vec ) {
+            unsigned n_ele = ( matA_n_vec >= _V)? _V : matA_n_vec;
+            _gf16v_generate_multabs_avx2( multabs, b, n_ele );
+            gf16mat_madd_multab_avx2(c, matA, matA_vec_byte, matA_n_vec, (const uint8_t *)multabs);
+            b += (n_ele >> 1);
+            matA += matA_vec_byte * n_ele;
+            matA_n_vec -= n_ele;
         }
-
-        matA_n_vec -= n_ele;
-        b += (n_ele >> 1);
-        matA += n_ele * matA_vec_byte;
     }
 }
 


### PR DESCRIPTION
These commits mainly removed the unused AVX2 code for matrix-vector multiplication w.r.t. the current UOV parameters. It should use smaller lines now.
For GF(256), it simply remove some redundant parts and didn't change much for the main computation. 