### PR TITLE
Revisit neon

### DIFF
--- a/src/neon/blas_matrix_neon.c
+++ b/src/neon/blas_matrix_neon.c
@@ -306,58 +306,66 @@ void gf16mat_prod_neon( uint8_t *c, const uint8_t *matA, unsigned matA_vec_byte,
 
 ///////////////////  matrix transpose ///////////////////
 
+static inline uint8x16_t _vtrn1q_u64( uint8x16_t a, uint8x16_t b) { return vreinterpretq_u8_u64(vtrn1q_u64(vreinterpretq_u64_u8(a),vreinterpretq_u64_u8(b))); }
+static inline uint8x16_t _vtrn2q_u64( uint8x16_t a, uint8x16_t b) { return vreinterpretq_u8_u64(vtrn2q_u64(vreinterpretq_u64_u8(a),vreinterpretq_u64_u8(b))); }
+static inline uint8x16_t _vtrn1q_u32( uint8x16_t a, uint8x16_t b) { return vreinterpretq_u8_u32(vtrn1q_u32(vreinterpretq_u32_u8(a),vreinterpretq_u32_u8(b))); }
+static inline uint8x16_t _vtrn2q_u32( uint8x16_t a, uint8x16_t b) { return vreinterpretq_u8_u32(vtrn2q_u32(vreinterpretq_u32_u8(a),vreinterpretq_u32_u8(b))); }
+static inline uint8x16_t _vtrn1q_u16( uint8x16_t a, uint8x16_t b) { return vreinterpretq_u8_u16(vtrn1q_u16(vreinterpretq_u16_u8(a),vreinterpretq_u16_u8(b))); }
+static inline uint8x16_t _vtrn2q_u16( uint8x16_t a, uint8x16_t b) { return vreinterpretq_u8_u16(vtrn2q_u16(vreinterpretq_u16_u8(a),vreinterpretq_u16_u8(b))); }
+
+
 static
 void byte_transpose_16x16_neon( uint8_t *dest, unsigned dest_vec_len, const uint8_t *src, unsigned src_vec_len ) {
-    uint8x16_t r0 = vtrn1q_u64( vld1q_u8( src + 0 * src_vec_len), vld1q_u8( src + 8 * src_vec_len) );
-    uint8x16_t r8 = vtrn2q_u64( vld1q_u8( src + 0 * src_vec_len), vld1q_u8( src + 8 * src_vec_len) );
-    uint8x16_t r1 = vtrn1q_u64( vld1q_u8( src + 1 * src_vec_len), vld1q_u8( src + 9 * src_vec_len) );
-    uint8x16_t r9 = vtrn2q_u64( vld1q_u8( src + 1 * src_vec_len), vld1q_u8( src + 9 * src_vec_len) );
-    uint8x16_t r2 = vtrn1q_u64( vld1q_u8( src + 2 * src_vec_len), vld1q_u8( src + 10 * src_vec_len) );
-    uint8x16_t r10 = vtrn2q_u64( vld1q_u8( src + 2 * src_vec_len), vld1q_u8( src + 10 * src_vec_len) );
-    uint8x16_t r3 = vtrn1q_u64( vld1q_u8( src + 3 * src_vec_len), vld1q_u8( src + 11 * src_vec_len) );
-    uint8x16_t r11 = vtrn2q_u64( vld1q_u8( src + 3 * src_vec_len), vld1q_u8( src + 11 * src_vec_len) );
-    uint8x16_t r4 = vtrn1q_u64( vld1q_u8( src + 4 * src_vec_len), vld1q_u8( src + 12 * src_vec_len) );
-    uint8x16_t r12 = vtrn2q_u64( vld1q_u8( src + 4 * src_vec_len), vld1q_u8( src + 12 * src_vec_len) );
-    uint8x16_t r5 = vtrn1q_u64( vld1q_u8( src + 5 * src_vec_len), vld1q_u8( src + 13 * src_vec_len) );
-    uint8x16_t r13 = vtrn2q_u64( vld1q_u8( src + 5 * src_vec_len), vld1q_u8( src + 13 * src_vec_len) );
-    uint8x16_t r6 = vtrn1q_u64( vld1q_u8( src + 6 * src_vec_len), vld1q_u8( src + 14 * src_vec_len) );
-    uint8x16_t r14 = vtrn2q_u64( vld1q_u8( src + 6 * src_vec_len), vld1q_u8( src + 14 * src_vec_len) );
-    uint8x16_t r7 = vtrn1q_u64( vld1q_u8( src + 7 * src_vec_len), vld1q_u8( src + 15 * src_vec_len) );
-    uint8x16_t r15 = vtrn2q_u64( vld1q_u8( src + 7 * src_vec_len), vld1q_u8( src + 15 * src_vec_len) );
+    uint8x16_t r0 = _vtrn1q_u64( vld1q_u8( src + 0 * src_vec_len), vld1q_u8( src + 8 * src_vec_len) );
+    uint8x16_t r8 = _vtrn2q_u64( vld1q_u8( src + 0 * src_vec_len), vld1q_u8( src + 8 * src_vec_len) );
+    uint8x16_t r1 = _vtrn1q_u64( vld1q_u8( src + 1 * src_vec_len), vld1q_u8( src + 9 * src_vec_len) );
+    uint8x16_t r9 = _vtrn2q_u64( vld1q_u8( src + 1 * src_vec_len), vld1q_u8( src + 9 * src_vec_len) );
+    uint8x16_t r2 = _vtrn1q_u64( vld1q_u8( src + 2 * src_vec_len), vld1q_u8( src + 10 * src_vec_len) );
+    uint8x16_t r10 = _vtrn2q_u64( vld1q_u8( src + 2 * src_vec_len), vld1q_u8( src + 10 * src_vec_len) );
+    uint8x16_t r3 = _vtrn1q_u64( vld1q_u8( src + 3 * src_vec_len), vld1q_u8( src + 11 * src_vec_len) );
+    uint8x16_t r11 = _vtrn2q_u64( vld1q_u8( src + 3 * src_vec_len), vld1q_u8( src + 11 * src_vec_len) );
+    uint8x16_t r4 = _vtrn1q_u64( vld1q_u8( src + 4 * src_vec_len), vld1q_u8( src + 12 * src_vec_len) );
+    uint8x16_t r12 = _vtrn2q_u64( vld1q_u8( src + 4 * src_vec_len), vld1q_u8( src + 12 * src_vec_len) );
+    uint8x16_t r5 = _vtrn1q_u64( vld1q_u8( src + 5 * src_vec_len), vld1q_u8( src + 13 * src_vec_len) );
+    uint8x16_t r13 = _vtrn2q_u64( vld1q_u8( src + 5 * src_vec_len), vld1q_u8( src + 13 * src_vec_len) );
+    uint8x16_t r6 = _vtrn1q_u64( vld1q_u8( src + 6 * src_vec_len), vld1q_u8( src + 14 * src_vec_len) );
+    uint8x16_t r14 = _vtrn2q_u64( vld1q_u8( src + 6 * src_vec_len), vld1q_u8( src + 14 * src_vec_len) );
+    uint8x16_t r7 = _vtrn1q_u64( vld1q_u8( src + 7 * src_vec_len), vld1q_u8( src + 15 * src_vec_len) );
+    uint8x16_t r15 = _vtrn2q_u64( vld1q_u8( src + 7 * src_vec_len), vld1q_u8( src + 15 * src_vec_len) );
 
-    uint8x16_t s0 = vtrn1q_u32( r0, r4 );
-    uint8x16_t s4 = vtrn2q_u32( r0, r4 );
-    uint8x16_t s1 = vtrn1q_u32( r1, r5 );
-    uint8x16_t s5 = vtrn2q_u32( r1, r5 );
-    uint8x16_t s2 = vtrn1q_u32( r2, r6 );
-    uint8x16_t s6 = vtrn2q_u32( r2, r6 );
-    uint8x16_t s3 = vtrn1q_u32( r3, r7 );
-    uint8x16_t s7 = vtrn2q_u32( r3, r7 );
-    uint8x16_t s8 = vtrn1q_u32( r8, r12 );
-    uint8x16_t s12 = vtrn2q_u32( r8, r12 );
-    uint8x16_t s9 = vtrn1q_u32( r9, r13 );
-    uint8x16_t s13 = vtrn2q_u32( r9, r13 );
-    uint8x16_t s10 = vtrn1q_u32( r10, r14 );
-    uint8x16_t s14 = vtrn2q_u32( r10, r14 );
-    uint8x16_t s11 = vtrn1q_u32( r11, r15 );
-    uint8x16_t s15 = vtrn2q_u32( r11, r15 );
+    uint8x16_t s0 = _vtrn1q_u32( r0, r4 );
+    uint8x16_t s4 = _vtrn2q_u32( r0, r4 );
+    uint8x16_t s1 = _vtrn1q_u32( r1, r5 );
+    uint8x16_t s5 = _vtrn2q_u32( r1, r5 );
+    uint8x16_t s2 = _vtrn1q_u32( r2, r6 );
+    uint8x16_t s6 = _vtrn2q_u32( r2, r6 );
+    uint8x16_t s3 = _vtrn1q_u32( r3, r7 );
+    uint8x16_t s7 = _vtrn2q_u32( r3, r7 );
+    uint8x16_t s8 = _vtrn1q_u32( r8, r12 );
+    uint8x16_t s12 = _vtrn2q_u32( r8, r12 );
+    uint8x16_t s9 = _vtrn1q_u32( r9, r13 );
+    uint8x16_t s13 = _vtrn2q_u32( r9, r13 );
+    uint8x16_t s10 = _vtrn1q_u32( r10, r14 );
+    uint8x16_t s14 = _vtrn2q_u32( r10, r14 );
+    uint8x16_t s11 = _vtrn1q_u32( r11, r15 );
+    uint8x16_t s15 = _vtrn2q_u32( r11, r15 );
 
-    r0 = vtrn1q_u16( s0, s2 );
-    r2 = vtrn2q_u16( s0, s2 );
-    r1 = vtrn1q_u16( s1, s3 );
-    r3 = vtrn2q_u16( s1, s3 );
-    r4 = vtrn1q_u16( s4, s6 );
-    r6 = vtrn2q_u16( s4, s6 );
-    r5 = vtrn1q_u16( s5, s7 );
-    r7 = vtrn2q_u16( s5, s7 );
-    r8 = vtrn1q_u16( s8, s10 );
-    r10 = vtrn2q_u16( s8, s10 );
-    r9 = vtrn1q_u16( s9, s11 );
-    r11 = vtrn2q_u16( s9, s11 );
-    r12 = vtrn1q_u16( s12, s14 );
-    r14 = vtrn2q_u16( s12, s14 );
-    r13 = vtrn1q_u16( s13, s15 );
-    r15 = vtrn2q_u16( s13, s15 );
+    r0 = _vtrn1q_u16( s0, s2 );
+    r2 = _vtrn2q_u16( s0, s2 );
+    r1 = _vtrn1q_u16( s1, s3 );
+    r3 = _vtrn2q_u16( s1, s3 );
+    r4 = _vtrn1q_u16( s4, s6 );
+    r6 = _vtrn2q_u16( s4, s6 );
+    r5 = _vtrn1q_u16( s5, s7 );
+    r7 = _vtrn2q_u16( s5, s7 );
+    r8 = _vtrn1q_u16( s8, s10 );
+    r10 = _vtrn2q_u16( s8, s10 );
+    r9 = _vtrn1q_u16( s9, s11 );
+    r11 = _vtrn2q_u16( s9, s11 );
+    r12 = _vtrn1q_u16( s12, s14 );
+    r14 = _vtrn2q_u16( s12, s14 );
+    r13 = _vtrn1q_u16( s13, s15 );
+    r15 = _vtrn2q_u16( s13, s15 );
 
     vst1q_u8( dest + 0 * dest_vec_len, vtrn1q_u8( r0, r1 ) );
     vst1q_u8( dest + 1 * dest_vec_len, vtrn2q_u8( r0, r1 ) );

--- a/src/neon/blas_matrix_neon.c
+++ b/src/neon/blas_matrix_neon.c
@@ -81,56 +81,55 @@ void gf16mat_prod_96x_multab_neon(uint8_t *c, const uint8_t *matA, unsigned widt
 
 
 static
-void gf16mat_blockmat_prod_multab_neon( uint8_t *dest, const uint8_t *org_mat, unsigned mat_vec_byte, unsigned blk_vec_byte,
+void gf16mat_remblockmat_prod_multab_neon( uint8_t *dest, const uint8_t *org_mat, unsigned mat_vec_byte, unsigned blk_vec_byte,
                                         const uint8x16_t *multab_vec_ele, unsigned n_vec_ele ) {
     unsigned n_full_xmm = blk_vec_byte >> 4;
-    unsigned n_rem_byte = blk_vec_byte & 15;
+    unsigned rem_byte = blk_vec_byte & 15;
     uint8x16_t mask_f = vdupq_n_u8(0xf);
 
     uint8x16_t tmp[BLOCK_LEN];
     for (int i = 0; i < BLOCK_LEN; i++) {
         tmp[i] = vdupq_n_u8(0);
     }
+    for (unsigned i = 0; i < n_vec_ele; i++ ) {
+        uint8x16_t tab = multab_vec_ele[0];
+        multab_vec_ele += 1;
 
-    if ( !n_rem_byte ) {
-        for (unsigned i = 0; i < n_vec_ele; i++ ) {
-            uint8x16_t tab = multab_vec_ele[0];
-            multab_vec_ele += 1;
+        tmp[0] ^= _gf16_tbl_x2( vld1q_u8( org_mat ), tab, mask_f );
+        for (unsigned j = 0; j < n_full_xmm; j++) {
+            uint8x16_t mj = vld1q_u8( org_mat + rem_byte + j * 16 );
+            tmp[1+j] ^= _gf16_tbl_x2( mj, tab, mask_f );
+        }
+        org_mat += mat_vec_byte;
+    }
+    vst1q_u8( dest , tmp[0] );
+    for (unsigned i = 0; i < n_full_xmm; i++) {
+        vst1q_u8(dest + rem_byte + i * 16, tmp[i+1]);
+    }
+}
 
-            for (unsigned j = 0; j < n_full_xmm; j++) {
-                uint8x16_t mj = vld1q_u8( org_mat + j * 16 );
-                tmp[j] ^= _gf16_tbl_x2( mj, tab, mask_f );
-            }
-            org_mat += mat_vec_byte;
-        }
-        for (unsigned i = 0; i < n_full_xmm; i++) {
-            vst1q_u8(dest + i * 16, tmp[i]);
-        }
-    } else { // n_rem_byte
-        for (unsigned i = 0; i < n_vec_ele - 1; i++ ) {
-            uint8x16_t tab = multab_vec_ele[0];
-            multab_vec_ele += 1;
+static
+void gf16mat_blockmat_prod_multab_neon( uint8_t *dest, const uint8_t *org_mat, unsigned mat_vec_byte, unsigned blk_vec_byte,
+                                        const uint8x16_t *multab_vec_ele, unsigned n_vec_ele ) {
+    unsigned n_full_xmm = blk_vec_byte >> 4;
+    uint8x16_t mask_f = vdupq_n_u8(0xf);
 
-            for (unsigned j = 0; j <= n_full_xmm; j++) { // note : <=
-                uint8x16_t mj = vld1q_u8( org_mat + j * 16 );
-                tmp[j] ^= _gf16_tbl_x2( mj, tab, mask_f );
-            }
-            org_mat += mat_vec_byte;
-        } { //unsigned i = n_vec_ele-1;
-            uint8x16_t tab = multab_vec_ele[0];
-            for (unsigned j = 0; j < n_full_xmm; j++) {
-                uint8x16_t mj = vld1q_u8( org_mat + j * 16 );
-                tmp[j] ^= _gf16_tbl_x2( mj, tab, mask_f );
-            } {
-                //unsigned j=n_full_xmm;
-                uint8x16_t mj = _load_Qreg( org_mat + (n_full_xmm * 16), n_rem_byte );
-                tmp[n_full_xmm] ^= _gf16_tbl_x2( mj, tab, mask_f );
-            }
+    uint8x16_t tmp[BLOCK_LEN];
+    for (int i = 0; i < BLOCK_LEN; i++) {
+        tmp[i] = vdupq_n_u8(0);
+    }
+    for (unsigned i = 0; i < n_vec_ele; i++ ) {
+        uint8x16_t tab = multab_vec_ele[0];
+        multab_vec_ele += 1;
+
+        for (unsigned j = 0; j < n_full_xmm; j++) {
+            uint8x16_t mj = vld1q_u8( org_mat + j * 16 );
+            tmp[j] ^= _gf16_tbl_x2( mj, tab, mask_f );
         }
-        for (unsigned i = 0; i < n_full_xmm + 1; i++) {
-            vst1q_u8(dest + i * 16, tmp[i]);
-        }
-        _store_Qreg( dest + n_full_xmm, n_rem_byte, tmp[n_full_xmm] );
+        org_mat += mat_vec_byte;
+    }
+    for (unsigned i = 0; i < n_full_xmm; i++) {
+        vst1q_u8(dest + i * 16, tmp[i]);
     }
 }
 
@@ -154,6 +153,13 @@ void gf16mat_prod_multab_neon( uint8_t *c, const uint8_t *matA, unsigned matA_ve
     while (matA_n_vec) {
         unsigned n_ele = matA_n_vec;
         unsigned vec_len_to_go = matA_vec_byte;
+        if (vec_len_to_go&15) {
+            unsigned rem = vec_len_to_go&15;
+            unsigned vec_len_fullreg = vec_len_to_go - rem;
+            unsigned block_len = (vec_len_fullreg >= (BLOCK_LEN-1)*16) ? (BLOCK_LEN-1)*16 : vec_len_fullreg;
+            gf16mat_remblockmat_prod_multab_neon( c , matA, matA_vec_byte, block_len+rem, multabs, n_ele);
+            vec_len_to_go -= (rem + block_len);
+        }
         while ( vec_len_to_go ) {
             unsigned block_len = (vec_len_to_go >= BLOCK_LEN * 16) ? BLOCK_LEN * 16 : vec_len_to_go;
             unsigned block_st_idx = matA_vec_byte - vec_len_to_go;
@@ -174,82 +180,82 @@ void gf16mat_prod_multab_neon( uint8_t *c, const uint8_t *matA, unsigned matA_ve
 
 
 
-
 static inline
 void gf16mat_prod_32x_neon(uint8_t *c, const uint8_t *matA, unsigned width_A, const uint8_t *b) {
-    uint8_t multabs[32 * 16];
-    uint8x16_t r = vdupq_n_u8(0);
-    uint8x16_t tmp;
-    while ( width_A >= 32 ) {
-        gf16v_generate_multabs_neon( multabs, b, 32 );
-        gf16mat_prod_32x_multab_neon( (uint8_t *)&tmp, matA, 32, multabs);
-        r ^= tmp;
-        b += 16;
-        width_A -= 32;
-        matA += 16 * 32;
+    uint8x16_t r0 = vdupq_n_u8(0);
+    uint8x16_t r1 = vdupq_n_u8(0);
+    uint8x16_t mask_f = vdupq_n_u8( 0xf );
+    for(unsigned i=0;i<width_A;i++) {
+        uint8x16_t bb = vdupq_n_u8( gf16v_get_ele(b,i) );
+        uint8x16_t tmp = vld1q_u8( matA );
+        r0 ^= clmul_8x8( tmp&mask_f , bb );
+        r1 ^= clmul_8x8( vshrq_n_u8(tmp,4) , bb );
+        matA += 16;
     }
-    if ( width_A ) {
-        gf16v_generate_multabs_neon( multabs, b, width_A );
-        gf16mat_prod_32x_multab_neon( (uint8_t *)&tmp, matA, width_A, multabs);
-        r ^= tmp;
-    }
-    vst1q_u8(c, r);
+    uint8x16_t tab_reduce = vld1q_u8(__gf16_reduce);
+    r0 ^= vqtbl1q_u8( tab_reduce, vshrq_n_u8(r0, 4) );
+    r1 ^= vqtbl1q_u8( tab_reduce, vshrq_n_u8(r1, 4) );
+    vst1q_u8(c, vsliq_n_u8(r0,r1,4));
 }
 
 static inline
 void gf16mat_prod_64x_neon(uint8_t *c, const uint8_t *matA, unsigned width_A, const uint8_t *b) {
-    uint8_t multabs[64 * 16];
-    uint8x16_t r[2];
-    r[0] = vdupq_n_u8(0);
-    r[1] = vdupq_n_u8(0);
-    uint8x16_t tmp[2];
-    while ( width_A >= 64 ) {
-        gf16v_generate_multabs_neon( multabs, b, 64 );
-        gf16mat_prod_64x_multab_neon( (uint8_t *)tmp, matA, 64, multabs);
-        r[0] ^= tmp[0];
-        r[1] ^= tmp[1];
-        b += 32;
-        width_A -= 64;
-        matA += 16 * 64 * 2;
+    uint8x16_t r0 = vdupq_n_u8(0);
+    uint8x16_t r1 = vdupq_n_u8(0);
+    uint8x16_t r2 = vdupq_n_u8(0);
+    uint8x16_t r3 = vdupq_n_u8(0);
+    uint8x16_t mask_f = vdupq_n_u8( 0xf );
+    for(unsigned i=0;i<width_A;i++) {
+        uint8x16_t bb = vdupq_n_u8( gf16v_get_ele(b,i) );
+        uint8x16_t tmp0 = vld1q_u8( matA );
+        uint8x16_t tmp1 = vld1q_u8( matA+16 );
+        r0 ^= clmul_8x8( tmp0&mask_f , bb );
+        r1 ^= clmul_8x8( vshrq_n_u8(tmp0,4) , bb );
+        r2 ^= clmul_8x8( tmp1&mask_f , bb );
+        r3 ^= clmul_8x8( vshrq_n_u8(tmp1,4) , bb );
+        matA += 32;
     }
-    if ( width_A ) {
-        gf16v_generate_multabs_neon( multabs, b, width_A );
-        gf16mat_prod_64x_multab_neon( (uint8_t *)tmp, matA, width_A, multabs);
-        r[0] ^= tmp[0];
-        r[1] ^= tmp[1];
-    }
-    vst1q_u8(c, r[0]);
-    vst1q_u8(c + 16, r[1]);
+    uint8x16_t tab_reduce = vld1q_u8(__gf16_reduce);
+    r0 ^= vqtbl1q_u8( tab_reduce, vshrq_n_u8(r0, 4) );
+    r1 ^= vqtbl1q_u8( tab_reduce, vshrq_n_u8(r1, 4) );
+    r2 ^= vqtbl1q_u8( tab_reduce, vshrq_n_u8(r2, 4) );
+    r3 ^= vqtbl1q_u8( tab_reduce, vshrq_n_u8(r3, 4) );
+    vst1q_u8(c, vsliq_n_u8(r0,r1,4));
+    vst1q_u8(c+16, vsliq_n_u8(r2,r3,4));
 }
 
 static inline
 void gf16mat_prod_96x_neon(uint8_t *c, const uint8_t *matA, unsigned width_A, const uint8_t *b) {
-    uint8_t multabs[64 * 16];
-    uint8x16_t r[3];
-    r[0] = vdupq_n_u8(0);
-    r[1] = vdupq_n_u8(0);
-    r[2] = vdupq_n_u8(0);
-    uint8x16_t tmp[3];
-    while ( width_A >= 64 ) {
-        gf16v_generate_multabs_neon( multabs, b, 64 );
-        gf16mat_prod_96x_multab_neon( (uint8_t *)tmp, matA, 64, multabs);
-        r[0] ^= tmp[0];
-        r[1] ^= tmp[1];
-        r[2] ^= tmp[2];
-        b += 32;
-        width_A -= 64;
-        matA += 16 * 64 * 3;
+    uint8x16_t r0 = vdupq_n_u8(0);
+    uint8x16_t r1 = vdupq_n_u8(0);
+    uint8x16_t r2 = vdupq_n_u8(0);
+    uint8x16_t r3 = vdupq_n_u8(0);
+    uint8x16_t r4 = vdupq_n_u8(0);
+    uint8x16_t r5 = vdupq_n_u8(0);
+    uint8x16_t mask_f = vdupq_n_u8( 0xf );
+    for(unsigned i=0;i<width_A;i++) {
+        uint8x16_t bb = vdupq_n_u8( gf16v_get_ele(b,i) );
+        uint8x16_t tmp0 = vld1q_u8( matA );
+        uint8x16_t tmp1 = vld1q_u8( matA+16 );
+        uint8x16_t tmp2 = vld1q_u8( matA+32 );
+        r0 ^= clmul_8x8( tmp0&mask_f , bb );
+        r1 ^= clmul_8x8( vshrq_n_u8(tmp0,4) , bb );
+        r2 ^= clmul_8x8( tmp1&mask_f , bb );
+        r3 ^= clmul_8x8( vshrq_n_u8(tmp1,4) , bb );
+        r4 ^= clmul_8x8( tmp2&mask_f , bb );
+        r5 ^= clmul_8x8( vshrq_n_u8(tmp2,4) , bb );
+        matA += 48;
     }
-    if ( width_A ) {
-        gf16v_generate_multabs_neon( multabs, b, width_A );
-        gf16mat_prod_96x_multab_neon( (uint8_t *)tmp, matA, width_A, multabs);
-        r[0] ^= tmp[0];
-        r[1] ^= tmp[1];
-        r[2] ^= tmp[2];
-    }
-    vst1q_u8(c, r[0]);
-    vst1q_u8(c + 16, r[1]);
-    vst1q_u8(c + 32, r[2]);
+    uint8x16_t tab_reduce = vld1q_u8(__gf16_reduce);
+    r0 ^= vqtbl1q_u8( tab_reduce, vshrq_n_u8(r0, 4) );
+    r1 ^= vqtbl1q_u8( tab_reduce, vshrq_n_u8(r1, 4) );
+    r2 ^= vqtbl1q_u8( tab_reduce, vshrq_n_u8(r2, 4) );
+    r3 ^= vqtbl1q_u8( tab_reduce, vshrq_n_u8(r3, 4) );
+    r4 ^= vqtbl1q_u8( tab_reduce, vshrq_n_u8(r4, 4) );
+    r5 ^= vqtbl1q_u8( tab_reduce, vshrq_n_u8(r5, 4) );
+    vst1q_u8(c, vsliq_n_u8(r0,r1,4));
+    vst1q_u8(c+16, vsliq_n_u8(r2,r3,4));
+    vst1q_u8(c+32, vsliq_n_u8(r4,r5,4));
 }
 
 
@@ -259,6 +265,67 @@ void gf16mat_prod_96x_neon(uint8_t *c, const uint8_t *matA, unsigned width_A, co
 
 #define BLOCK_LEN 4
 
+
+static
+void gf16mat_remblockmat_prod_neon( uint8_t *dest, const uint8_t *org_mat, unsigned mat_vec_byte, unsigned blk_vec_byte, const uint8_t *b, unsigned n_vec_ele ) {
+    unsigned n_full_xmm = blk_vec_byte >> 4;
+    unsigned rem_byte = blk_vec_byte & 15;
+    uint8x16_t mask_f = vdupq_n_u8(0xf);
+
+    uint8x16_t tmp0[BLOCK_LEN];
+    uint8x16_t tmp1[BLOCK_LEN];
+    for (int i = 0; i < BLOCK_LEN; i++) { tmp0[i] = vdupq_n_u8(0); }
+    for (int i = 0; i < BLOCK_LEN; i++) { tmp1[i] = vdupq_n_u8(0); }
+
+    for (unsigned i = 0; i < n_vec_ele; i++ ) {
+        uint8x16_t bb = vdupq_n_u8( gf16v_get_ele(b,i) );
+        uint8x16_t tt = vld1q_u8(org_mat);
+        tmp0[0] ^= clmul_8x8( tt&mask_f, bb );
+        tmp1[0] ^= clmul_8x8( vshrq_n_u8(tt,4), bb );
+        for (unsigned j = 0; j < n_full_xmm; j++) {
+            uint8x16_t mj = vld1q_u8( org_mat + rem_byte + j * 16 );
+            tmp0[1+j] ^= clmul_8x8( mj&mask_f, bb );
+            tmp1[1+j] ^= clmul_8x8( vshrq_n_u8(mj,4), bb );
+        }
+        org_mat += mat_vec_byte;
+    }
+    uint8x16_t tab_reduce = vld1q_u8(__gf16_reduce);
+    for (int i = 0; i < BLOCK_LEN; i++) { tmp0[i] ^= vqtbl1q_u8( tab_reduce, vshrq_n_u8(tmp0[i], 4) ); }
+    for (int i = 0; i < BLOCK_LEN; i++) { tmp1[i] ^= vqtbl1q_u8( tab_reduce, vshrq_n_u8(tmp1[i], 4) ); }
+
+    vst1q_u8( dest , vsliq_n_u8(tmp0[0],tmp1[0],4) );
+    for (unsigned i = 0; i < n_full_xmm; i++) {
+        vst1q_u8( dest + rem_byte +i * 16 , vsliq_n_u8(tmp0[1+i],tmp1[1+i],4) );
+    }
+}
+
+static
+void gf16mat_blockmat_prod_neon( uint8_t *dest, const uint8_t *org_mat, unsigned mat_vec_byte, unsigned blk_vec_byte, const uint8_t *b, unsigned n_vec_ele ) {
+    unsigned n_full_xmm = blk_vec_byte >> 4;
+    uint8x16_t mask_f = vdupq_n_u8(0xf);
+
+    uint8x16_t tmp0[BLOCK_LEN];
+    uint8x16_t tmp1[BLOCK_LEN];
+    for (int i = 0; i < BLOCK_LEN; i++) { tmp0[i] = vdupq_n_u8(0); }
+    for (int i = 0; i < BLOCK_LEN; i++) { tmp1[i] = vdupq_n_u8(0); }
+
+    for (unsigned i = 0; i < n_vec_ele; i++ ) {
+        uint8x16_t bb = vdupq_n_u8( gf16v_get_ele(b,i) );
+        for (unsigned j = 0; j < n_full_xmm; j++) {
+            uint8x16_t mj = vld1q_u8( org_mat + j * 16 );
+            tmp0[j] ^= clmul_8x8( mj&mask_f, bb );
+            tmp1[j] ^= clmul_8x8( vshrq_n_u8(mj,4), bb );
+        }
+        org_mat += mat_vec_byte;
+    }
+    uint8x16_t tab_reduce = vld1q_u8(__gf16_reduce);
+    for (int i = 0; i < BLOCK_LEN; i++) { tmp0[i] ^= vqtbl1q_u8( tab_reduce, vshrq_n_u8(tmp0[i], 4) ); }
+    for (int i = 0; i < BLOCK_LEN; i++) { tmp1[i] ^= vqtbl1q_u8( tab_reduce, vshrq_n_u8(tmp1[i], 4) ); }
+
+    for (unsigned i = 0; i < n_full_xmm; i++) {
+        vst1q_u8( dest + i * 16 , vsliq_n_u8(tmp0[i],tmp1[i],4) );
+    }
+}
 
 void gf16mat_prod_neon( uint8_t *c, const uint8_t *matA, unsigned matA_vec_byte, unsigned matA_n_vec, const uint8_t *b ) {
     if ( (32 == matA_vec_byte) ) {
@@ -274,26 +341,23 @@ void gf16mat_prod_neon( uint8_t *c, const uint8_t *matA, unsigned matA_vec_byte,
         return;
     }
 
-    uint8_t multabs[16 * 64];
-    gf256v_set_zero_neon( c, matA_vec_byte );
-
-    uint8_t blockmat_vec[BLOCK_LEN * 16];
     while (matA_n_vec) {
-
-        unsigned n_ele = (matA_n_vec >= 64) ? 64 : matA_n_vec;
-        gf16v_generate_multabs_neon( multabs, b, n_ele );
+        unsigned n_ele = matA_n_vec;
 
         unsigned vec_len_to_go = matA_vec_byte;
+        if (vec_len_to_go&15) {
+            unsigned rem = vec_len_to_go&15;
+            unsigned vec_len_fullreg = vec_len_to_go - rem;
+            unsigned block_len = (vec_len_fullreg >= (BLOCK_LEN-1)*16) ? (BLOCK_LEN-1)*16 : vec_len_fullreg;
+            gf16mat_remblockmat_prod_neon( c , matA, matA_vec_byte, block_len+rem, b, n_ele);
+            vec_len_to_go -= (rem + block_len);
+        }
         while ( vec_len_to_go ) {
             unsigned block_len = (vec_len_to_go >= BLOCK_LEN * 16) ? BLOCK_LEN * 16 : vec_len_to_go;
             unsigned block_st_idx = matA_vec_byte - vec_len_to_go;
-
-            gf16mat_blockmat_prod_multab_neon( blockmat_vec, matA + block_st_idx, matA_vec_byte, block_len, (uint8x16_t *)multabs, n_ele );
-            gf256v_add_neon( c + block_st_idx, blockmat_vec, block_len );
-
+            gf16mat_blockmat_prod_neon( c + block_st_idx, matA + block_st_idx, matA_vec_byte, block_len, b, n_ele );
             vec_len_to_go -= block_len;
         }
-
         matA_n_vec -= n_ele;
         b += (n_ele + 1) >> 1;
         matA += n_ele * matA_vec_byte;

--- a/src/neon/blas_neon.h
+++ b/src/neon/blas_neon.h
@@ -11,7 +11,7 @@
 
 #include "gf16_neon.h"
 
-
+#include <arm_neon.h>
 //#include "assert.h"
 
 

--- a/src/neon/blas_neon.h
+++ b/src/neon/blas_neon.h
@@ -115,12 +115,10 @@ void gf256v_add_neon( uint8_t *accu_b, const uint8_t *a, unsigned _num_byte ) {
     }
     //for(unsigned j=0;j<_num_byte;j++) { accu_b[j] ^= a[j]; }
 #if !defined(_MW_)
-    if (_num_byte < 16 ) {
-        while ( _num_byte-- ) {
-            *accu_b ^= *a;
-            accu_b++;
-            a++;
-        }
+    while ( _num_byte-- ) {
+        *accu_b ^= *a;
+        accu_b++;
+        a++;
     }
 #endif
 }

--- a/src/neon/blas_neon.h
+++ b/src/neon/blas_neon.h
@@ -67,11 +67,32 @@ void store_Qregs( uint8_t *v, unsigned n, const uint8x16_t *r ) {
 
 //////////////////////   basic functions  ///////////////////////////////////////////////
 
-
+#define _MW_
 
 
 static inline
 void gf256v_add_neon( uint8_t *accu_b, const uint8_t *a, unsigned _num_byte ) {
+#if defined(_MW_)
+    if( _num_byte & 15 ) {
+        unsigned len = _num_byte & 15;
+        if (_num_byte < 16 ) {
+            while ( _num_byte-- ) {
+                *accu_b ^= *a;
+                accu_b++;
+                a++;
+            }
+            return;
+        } else {
+            uint8x16_t b0 = vld1q_u8(accu_b);
+            uint8x16_t b1 = vld1q_u8(accu_b+len);
+            vst1q_u8( accu_b, vld1q_u8(a)^b0 );
+            vst1q_u8( accu_b+len, b1 );
+            _num_byte -= len;
+            a += len;
+            accu_b += len;
+        }
+    }
+#endif
     while ( _num_byte >= 48 ) {
         uint8x16_t a0 = vld1q_u8(a);
         uint8x16_t a1 = vld1q_u8(a + 16);
@@ -93,11 +114,15 @@ void gf256v_add_neon( uint8_t *accu_b, const uint8_t *a, unsigned _num_byte ) {
         accu_b += 16;
     }
     //for(unsigned j=0;j<_num_byte;j++) { accu_b[j] ^= a[j]; }
-    while ( _num_byte-- ) {
-        *accu_b ^= *a;
-        accu_b++;
-        a++;
+#if !defined(_MW_)
+    if (_num_byte < 16 ) {
+        while ( _num_byte-- ) {
+            *accu_b ^= *a;
+            accu_b++;
+            a++;
+        }
     }
+#endif
 }
 
 static inline
@@ -144,13 +169,32 @@ void gf16v_mul_scalar_neon( uint8_t *a, uint8_t gf16_b, unsigned _num_byte ) {
     #else
     uint8x16_t mask_3 = vdupq_n_u8( 3 );
     #endif
-
+#if defined(_MW_)
+    if (_num_byte&15) {
+        unsigned len = _num_byte & 15;
+        if ( _num_byte < 16 ){
+            uint8x16_t aa = _load_Qreg(a,len);
+            uint8x16_t ab = _gf16v_mul_neon(aa,bp,mask_f,mask_3);
+            _store_Qreg(a, len, ab);
+            return;
+        } else {
+            uint8x16_t a0 = vld1q_u8(a);
+            uint8x16_t a1 = vld1q_u8(a+len);
+            uint8x16_t ab = _gf16v_mul_neon(a0,bp,mask_f,mask_3);
+            vst1q_u8(a,ab);
+            vst1q_u8(a+len,a1);
+            _num_byte -= len;
+            a += len;
+        }
+    }
+#endif
     while ( _num_byte >= 16 ) {
         uint8x16_t aa = vld1q_u8(a);
         vst1q_u8( a, _gf16v_mul_neon(aa, bp, mask_f, mask_3) );
         _num_byte -= 16;
         a += 16;
     }
+#if !defined(_MW_)
     if (_num_byte) {
         uint8_t temp[16];
         for (unsigned j = 0; j < _num_byte; j++) {
@@ -162,6 +206,7 @@ void gf16v_mul_scalar_neon( uint8_t *a, uint8_t gf16_b, unsigned _num_byte ) {
             a[j] = temp[j];
         }
     }
+#endif
 }
 
 
@@ -175,6 +220,28 @@ void gf16v_madd_neon( uint8_t *accu_c, const uint8_t *a, uint8_t gf16_b, unsigne
     #else
     uint8x16_t mask_3 = vdupq_n_u8( 3 );
     #endif
+#if defined(_MW_)
+    if (_num_byte&15) {
+        unsigned len = _num_byte & 15;
+        if ( _num_byte < 16 ){
+            uint8x16_t aa = _load_Qreg(a,len);
+            uint8x16_t cc = _load_Qreg(accu_c,len);
+            uint8x16_t ab = cc ^ _gf16v_mul_neon(aa,bp,mask_f,mask_3);
+            _store_Qreg(accu_c, len, ab);
+            return;
+        } else {
+            uint8x16_t a0 = vld1q_u8(a);
+            uint8x16_t c0 = vld1q_u8(accu_c);
+            uint8x16_t c1 = vld1q_u8(accu_c+len);
+            uint8x16_t ab = c0 ^ _gf16v_mul_neon(a0,bp,mask_f,mask_3);
+            vst1q_u8(accu_c,ab);
+            vst1q_u8(accu_c+len,c1);
+            _num_byte -= len;
+            a += len;
+            accu_c += len;
+        }
+    }
+#endif
     while ( _num_byte >= 16 ) {
         uint8x16_t aa = vld1q_u8(a);
         uint8x16_t cc = vld1q_u8(accu_c);
@@ -183,8 +250,9 @@ void gf16v_madd_neon( uint8_t *accu_c, const uint8_t *a, uint8_t gf16_b, unsigne
         a += 16;
         accu_c += 16;
     }
+#if !defined(_MW_)
     if (_num_byte) {
-        uint8_t temp[16] = {0};
+        uint8_t temp[16];
         for (unsigned j = 0; j < _num_byte; j++) {
             temp[j] = a[j];
         }
@@ -194,6 +262,7 @@ void gf16v_madd_neon( uint8_t *accu_c, const uint8_t *a, uint8_t gf16_b, unsigne
             accu_c[j] ^= temp[j];
         }
     }
+#endif
 }
 
 
@@ -203,6 +272,26 @@ void gf16v_madd_multab_neon( uint8_t *accu_c, const uint8_t *a, const uint8_t *m
     uint8x16_t mask_f = vdupq_n_u8( 0xf );
     uint8x16_t tbl = vld1q_u8( multab );
 
+#if defined(_MW_)
+    if (_num_byte&15) {
+        unsigned len = _num_byte & 15;
+        if ( _num_byte < 16 ){
+            uint8x16_t aa = _load_Qreg( a, _num_byte );
+            uint8x16_t cc = _load_Qreg( accu_c, _num_byte );
+            _store_Qreg( accu_c, _num_byte, cc ^ _gf16_tbl_x2(aa, tbl, mask_f) );
+            return;
+        } else {
+            uint8x16_t aa = vld1q_u8(a);
+            uint8x16_t cc = vld1q_u8(accu_c);
+            uint8x16_t c1 = vld1q_u8(accu_c+len);
+            vst1q_u8(accu_c, cc ^ _gf16_tbl_x2(aa, tbl, mask_f) );
+            vst1q_u8(accu_c+len,c1);
+            _num_byte -= len;
+            a += len;
+            accu_c += len;
+        }
+    }
+#endif
     while ( _num_byte >= 16 ) {
         uint8x16_t aa = vld1q_u8(a);
         uint8x16_t cc = vld1q_u8(accu_c);
@@ -211,11 +300,13 @@ void gf16v_madd_multab_neon( uint8_t *accu_c, const uint8_t *a, const uint8_t *m
         a += 16;
         accu_c += 16;
     }
+#if !defined(_MW_)
     if (_num_byte) {
         uint8x16_t aa = _load_Qreg( a, _num_byte );
         uint8x16_t cc = _load_Qreg( accu_c, _num_byte );
         _store_Qreg( accu_c, _num_byte, cc ^ _gf16_tbl_x2(aa, tbl, mask_f) );
     }
+#endif
 }
 
 
@@ -230,18 +321,26 @@ uint8x16_t _gf256_tbl( uint8x16_t a, uint8x16_t tbl0, uint8x16_t tbl1, uint8x16_
 }
 
 
-// WARNING: Assuming _num_byte >= 16
 static inline
 void _gf256v_madd_multab_neon( uint8_t *accu_c, const uint8_t *a,
                                uint8x16_t tbl0, uint8x16_t tbl1, unsigned _num_byte, uint8x16_t mask_f ) {
     if (15 & _num_byte) {
-        uint8x16_t aa = vld1q_u8(a);
-        uint8x16_t cc = vld1q_u8(accu_c);
         unsigned len = 15 & _num_byte;
-        _store_Qreg( accu_c, len, cc ^ _gf256_tbl(aa, tbl0, tbl1, mask_f) );
-        _num_byte -= len;
-        accu_c += len;
-        a += len;
+        if ( _num_byte < 16 ) {
+            uint8x16_t aa = _load_Qreg(a,len);
+            uint8x16_t cc = _load_Qreg(accu_c,len);
+            _store_Qreg( accu_c, len, cc ^ _gf256_tbl(aa, tbl0, tbl1, mask_f) );
+            return;
+        } else {
+            uint8x16_t aa = vld1q_u8(a);
+            uint8x16_t cc = vld1q_u8(accu_c);
+            uint8x16_t c1 = vld1q_u8(accu_c+len);
+            vst1q_u8( accu_c, cc ^ _gf256_tbl(aa, tbl0, tbl1, mask_f) );
+            vst1q_u8( accu_c + len , c1 );
+            _num_byte -= len;
+            accu_c += len;
+            a += len;
+        }
     }
     while ( _num_byte >= 48 ) {
         uint8x16_t a0 = vld1q_u8(a);
@@ -272,13 +371,7 @@ void gf256v_madd_multab_neon( uint8_t *accu_c, const uint8_t *a, const uint8_t *
     uint8x16_t mask_f = vdupq_n_u8( 0xf );
     uint8x16_t tbl0 = vld1q_u8( multab );
     uint8x16_t tbl1 = vld1q_u8( multab + 16 );
-    if (16 > _num_byte) {
-        uint8x16_t aa = _load_Qreg(a, _num_byte);
-        uint8x16_t cc = _load_Qreg(accu_c, _num_byte);
-        _store_Qreg( accu_c, _num_byte, cc ^ _gf256_tbl(aa, tbl0, tbl1, mask_f) );
-    } else {
-        _gf256v_madd_multab_neon( accu_c, a, tbl0, tbl1, _num_byte, mask_f );
-    }
+    _gf256v_madd_multab_neon( accu_c, a, tbl0, tbl1, _num_byte, mask_f );
 }
 
 
@@ -288,9 +381,11 @@ void _gf256v_mul_scalar_multab_neon( uint8_t *c, uint8x16_t tbl0, uint8x16_t tbl
     if (15 & _num_byte) {
         unsigned len = 15 & _num_byte;
         uint8x16_t cc = vld1q_u8( c );
-        _store_Qreg( c, len, _gf256_tbl(cc, tbl0, tbl1, mask_f) );
-        c += len;
+        uint8x16_t c1 = vld1q_u8( c+len );
+        vst1q_u8( c, _gf256_tbl(cc, tbl0, tbl1, mask_f) );
+        vst1q_u8( c + len , c1 );
         _num_byte -= len;
+        c += len;
     }
     while ( _num_byte ) {
         uint8x16_t cc = vld1q_u8(c);
@@ -327,6 +422,31 @@ void gf256v_mul_scalar_pmul_neon( uint8_t *a, uint8_t b, unsigned _num_byte ) {
     uint8x16_t mask_0x1b = vdupq_n_u8( 0x1b );
     uint8x16_t mask_3 = vdupq_n_u8( 3 );
     #endif
+    if (_num_byte & 15) {
+        if (_num_byte < 16 ) {
+            uint8x16_t aa = _load_Qreg(a, _num_byte);
+            #if defined(_GF256_REDUCE_WITH_TBL_)
+            uint8x16_t bb = _gf256v_mul_neon(aa, bp, mask_f, tab_rd0, tab_rd1);
+            #else
+            uint8x16_t bb = _gf256v_mul_neon(aa, bp, mask_3, mask_0x1b);
+            #endif
+            _store_Qreg( a, _num_byte, bb );
+            return;
+        } else {
+            unsigned len = _num_byte & 15;
+            uint8x16_t aa = vld1q_u8(a);
+            uint8x16_t a1 = vld1q_u8(a+len);
+            #if defined(_GF256_REDUCE_WITH_TBL_)
+            uint8x16_t bb = _gf256v_mul_neon(aa, bp, mask_f, tab_rd0, tab_rd1);
+            #else
+            uint8x16_t bb = _gf256v_mul_neon(aa, bp, mask_3, mask_0x1b);
+            #endif
+            vst1q_u8( a, bb );
+            vst1q_u8( a+len , a1 );
+            a += len;
+            _num_byte -= len;
+        }
+    }
     while ( _num_byte >= 16 ) {
         uint8x16_t aa = vld1q_u8(a);
         #if defined(_GF256_REDUCE_WITH_TBL_)
@@ -336,15 +456,6 @@ void gf256v_mul_scalar_pmul_neon( uint8_t *a, uint8_t b, unsigned _num_byte ) {
         #endif
         _num_byte -= 16;
         a += 16;
-    }
-    if (_num_byte) {
-        uint8x16_t aa = _load_Qreg(a, _num_byte);
-        #if defined(_GF256_REDUCE_WITH_TBL_)
-        uint8x16_t bb = _gf256v_mul_neon(aa, bp, mask_f, tab_rd0, tab_rd1);
-        #else
-        uint8x16_t bb = _gf256v_mul_neon(aa, bp, mask_3, mask_0x1b);
-        #endif
-        _store_Qreg( a, _num_byte, bb );
     }
 }
 
@@ -360,7 +471,34 @@ void gf256v_madd_pmul_neon( uint8_t *accu_c, const uint8_t *a, uint8_t b, unsign
     uint8x16_t mask_0x1b = vdupq_n_u8( 0x1b );
     uint8x16_t mask_3 = vdupq_n_u8( 3 );
     #endif
-
+    if (_num_byte) {
+        if (_num_byte < 16 ){
+            uint8x16_t aa = _load_Qreg(a, _num_byte);
+            uint8x16_t cc = _load_Qreg(accu_c, _num_byte);
+            #if defined(_GF256_REDUCE_WITH_TBL_)
+            uint8x16_t bb = _gf256v_mul_neon(aa, bp, mask_f, tab_rd0, tab_rd1);
+            #else
+            uint8x16_t bb = _gf256v_mul_neon(aa, bp, mask_3, mask_0x1b);
+            #endif
+            _store_Qreg( accu_c, _num_byte, bb ^ cc );
+            return;
+        } else {
+            unsigned len = _num_byte & 15;
+            uint8x16_t aa = vld1q_u8(a);
+            uint8x16_t cc = vld1q_u8(accu_c);
+            uint8x16_t c1 = vld1q_u8(accu_c+len);
+            #if defined(_GF256_REDUCE_WITH_TBL_)
+            uint8x16_t bb = _gf256v_mul_neon(aa, bp, mask_f, tab_rd0, tab_rd1);
+            #else
+            uint8x16_t bb = _gf256v_mul_neon(aa, bp, mask_3, mask_0x1b);
+            #endif
+            vst1q_u8( accu_c, bb ^ cc );
+            vst1q_u8( accu_c+len , c1 );
+            a += len;
+            accu_c += len;
+            _num_byte -= len;
+        }
+    }
     while ( _num_byte >= 16 ) {
         uint8x16_t aa = vld1q_u8(a);
         uint8x16_t cc = vld1q_u8(accu_c);
@@ -373,17 +511,6 @@ void gf256v_madd_pmul_neon( uint8_t *accu_c, const uint8_t *a, uint8_t b, unsign
         a += 16;
         accu_c += 16;
     }
-    if (_num_byte) {
-        uint8x16_t aa = _load_Qreg(a, _num_byte);
-        uint8x16_t cc = _load_Qreg(accu_c, _num_byte);
-        #if defined(_GF256_REDUCE_WITH_TBL_)
-        uint8x16_t bb = _gf256v_mul_neon(aa, bp, mask_f, tab_rd0, tab_rd1);
-        #else
-        uint8x16_t bb = _gf256v_mul_neon(aa, bp, mask_3, mask_0x1b);
-        #endif
-        _store_Qreg( accu_c, _num_byte, bb ^ cc );
-    }
-
 }
 
 

--- a/utils/neon_aesinst/aes_neonaes.c
+++ b/utils/neon_aesinst/aes_neonaes.c
@@ -10,13 +10,13 @@ void aes256ctrx4_enc_neonaes( uint8_t *ct, const uint8_t *nonce, uint32_t ctr, c
     static const uint32_t mask[4] = {0, 1, 2, 3};
     uint32x4_t idx   = vld1q_u32( mask );
     uint32x4_t ctrx4 = vdupq_n_u32( ctr );
-    uint32x4_t ctrx4_be = vrev32q_u8( vaddq_u32(ctrx4, idx) ); // to big endian numbers
+    uint32x4_t ctrx4_be = vreinterpretq_u32_u8(vrev32q_u8( vreinterpretq_u8_u32(vaddq_u32(ctrx4, idx)) )); // to big endian numbers
 
-    uint8x16_t iv = vld1q_u8(nonce);
-    uint8x16_t p0 = vcopyq_laneq_u32( iv, 3, ctrx4_be, 0 );
-    uint8x16_t p1 = vcopyq_laneq_u32( iv, 3, ctrx4_be, 1 );
-    uint8x16_t p2 = vcopyq_laneq_u32( iv, 3, ctrx4_be, 2 );
-    uint8x16_t p3 = vcopyq_laneq_u32( iv, 3, ctrx4_be, 3 );
+    uint32x4_t iv = vreinterpretq_u32_u8(vld1q_u8(nonce));
+    uint8x16_t p0 = vreinterpretq_u8_u32(vcopyq_laneq_u32( iv, 3, ctrx4_be, 0 ));
+    uint8x16_t p1 = vreinterpretq_u8_u32(vcopyq_laneq_u32( iv, 3, ctrx4_be, 1 ));
+    uint8x16_t p2 = vreinterpretq_u8_u32(vcopyq_laneq_u32( iv, 3, ctrx4_be, 2 ));
+    uint8x16_t p3 = vreinterpretq_u8_u32(vcopyq_laneq_u32( iv, 3, ctrx4_be, 3 ));
 
     uint8x16_t rki;
     for (int i = 0; i < 13; i++) {
@@ -52,13 +52,13 @@ void aes128ctrx4_enc_neonaes( uint8_t *ct, const uint8_t *nonce, uint32_t ctr, c
     static const uint32_t mask[4] = {0, 1, 2, 3};
     uint32x4_t idx   = vld1q_u32( mask );
     uint32x4_t ctrx4 = vdupq_n_u32( ctr );
-    uint32x4_t ctrx4_be = vrev32q_u8( vaddq_u32(ctrx4, idx) ); // to big endian numbers
+    uint32x4_t ctrx4_be = vreinterpretq_u32_u8(vrev32q_u8( vreinterpretq_u8_u32(vaddq_u32(ctrx4, idx)) )); // to big endian numbers
 
-    uint8x16_t iv = vld1q_u8(nonce);
-    uint8x16_t p0 = vcopyq_laneq_u32( iv, 3, ctrx4_be, 0 );
-    uint8x16_t p1 = vcopyq_laneq_u32( iv, 3, ctrx4_be, 1 );
-    uint8x16_t p2 = vcopyq_laneq_u32( iv, 3, ctrx4_be, 2 );
-    uint8x16_t p3 = vcopyq_laneq_u32( iv, 3, ctrx4_be, 3 );
+    uint32x4_t iv = vreinterpretq_u32_u8(vld1q_u8(nonce));
+    uint8x16_t p0 = vreinterpretq_u8_u32(vcopyq_laneq_u32( iv, 3, ctrx4_be, 0 ));
+    uint8x16_t p1 = vreinterpretq_u8_u32(vcopyq_laneq_u32( iv, 3, ctrx4_be, 1 ));
+    uint8x16_t p2 = vreinterpretq_u8_u32(vcopyq_laneq_u32( iv, 3, ctrx4_be, 2 ));
+    uint8x16_t p3 = vreinterpretq_u8_u32(vcopyq_laneq_u32( iv, 3, ctrx4_be, 3 ));
 
     uint8x16_t rki;
     for (int i = 0; i < 9; i++) {
@@ -94,13 +94,13 @@ void aes128ctrx4_4r_enc_neonaes( uint8_t *ct, const uint8_t *nonce, uint32_t ctr
     static const uint32_t mask[4] = {0, 1, 2, 3};
     uint32x4_t idx   = vld1q_u32( mask );
     uint32x4_t ctrx4 = vdupq_n_u32( ctr );
-    uint32x4_t ctrx4_be = vrev32q_u8( vaddq_u32(ctrx4, idx) ); // to big endian numbers
+    uint32x4_t ctrx4_be = vreinterpretq_u32_u8(vrev32q_u8( vreinterpretq_u8_u32(vaddq_u32(ctrx4, idx)) )); // to big endian numbers
 
-    uint8x16_t iv = vld1q_u8(nonce);
-    uint8x16_t p0 = vcopyq_laneq_u32( iv, 3, ctrx4_be, 0 );
-    uint8x16_t p1 = vcopyq_laneq_u32( iv, 3, ctrx4_be, 1 );
-    uint8x16_t p2 = vcopyq_laneq_u32( iv, 3, ctrx4_be, 2 );
-    uint8x16_t p3 = vcopyq_laneq_u32( iv, 3, ctrx4_be, 3 );
+    uint32x4_t iv = vreinterpretq_u32_u8(vld1q_u8(nonce));
+    uint8x16_t p0 = vreinterpretq_u8_u32(vcopyq_laneq_u32( iv, 3, ctrx4_be, 0 ));
+    uint8x16_t p1 = vreinterpretq_u8_u32(vcopyq_laneq_u32( iv, 3, ctrx4_be, 1 ));
+    uint8x16_t p2 = vreinterpretq_u8_u32(vcopyq_laneq_u32( iv, 3, ctrx4_be, 2 ));
+    uint8x16_t p3 = vreinterpretq_u8_u32(vcopyq_laneq_u32( iv, 3, ctrx4_be, 3 ));
 
     uint8x16_t rki;
     for (int i = 0; i < 3; i++) {
@@ -198,7 +198,7 @@ static uint8_t rcon[11] = {
 static inline
 uint32_t sbox( uint32_t w ) {
     uint32x4_t ww = vdupq_n_u32( w );
-    uint32x4_t w1 = vaeseq_u8( ww, vdupq_n_u8(0) );
+    uint32x4_t w1 = vreinterpretq_u32_u8(vaeseq_u8( vreinterpretq_u8_u32(ww), vdupq_n_u8(0) ));
     return vgetq_lane_u32( w1, 0 );
 }
 
@@ -206,7 +206,7 @@ uint32_t sbox( uint32_t w ) {
 static inline
 uint32_t sbox_ror( uint32_t w ) {
     uint32x4_t ww = vdupq_n_u32( w );
-    uint32x4_t w1 = vaeseq_u8( ww, vdupq_n_u8(0) );
+    uint32x4_t w1 = vreinterpretq_u32_u8(vaeseq_u8( vreinterpretq_u8_u32(ww), vdupq_n_u8(0) ));
     uint32x4_t w2 = vsliq_n_u32( vshrq_n_u32(w1, 8), w1, 24 );
     return vgetq_lane_u32( w2, 0 );
 }


### PR DESCRIPTION
1. Fix many type mismatches while compiling with gcc.
2. Use unaligned memory load/store to process vectors of non-16-byte-multiple lengths. (see macro _MW_ in blas_neon.h) 