### PR TITLE
remove macro:_MUL_WITH_MULTAB_ from ov.c

### DIFF
--- a/src/ov.c
+++ b/src/ov.c
@@ -44,10 +44,6 @@ int ov_sign( uint8_t *signature, const sk_t *sk, const uint8_t *message, size_t 
     uint8_t y[_PUB_N_BYTE];
     uint8_t x_o1[_O_BYTE];
 
-    #if defined(_MUL_WITH_MULTAB_)
-    uint8_t multabs[(_V) * 32] __attribute__((aligned(32)));
-    #endif
-
     hash_ctx h_m_salt_secret;
     hash_ctx h_vinegar_copy;
     // The computation:  H(M||salt)  -->   y  --C-map-->   x   --T-->   w
@@ -73,21 +69,11 @@ int ov_sign( uint8_t *signature, const sk_t *sk, const uint8_t *message, size_t 
         #endif
 
 // generate linear system:
-        #if !defined(_MUL_WITH_MULTAB_)
 // matrix
         gfmat_prod( mat_l1, sk->S, _O * _O_BYTE, _V, vinegar );
 // constant
         // Given vinegars, evaluate P1 with the vinegars
         batch_quad_trimat_eval( r_l1_F1, sk->P1, vinegar, _V, _O_BYTE );
-        #else
-// generate mul-tables of vinegars
-        gfv_generate_multabs( multabs, vinegar, _V );
-// matrix
-        gfmat_prod_multab( mat_l1, sk->S, _O * _O_BYTE, _V, multabs );
-// constant
-        // Given vinegars, evaluate P1 with the vinegars
-        batch_quad_trimat_eval_multab( r_l1_F1, sk->P1, multabs, _V, _O_BYTE );
-        #endif
         gf256v_add( r_l1_F1, y, _O_BYTE );      // substract the contribution from vinegar variables
 
 // solve linear system:

--- a/src/ov_blas.h
+++ b/src/ov_blas.h
@@ -49,7 +49,6 @@
 #define batch_2trimat_madd_multab   batch_2trimat_madd_multab_gf16
 #define batch_matTr_madd_multab     batch_matTr_madd_multab_gf16
 #define batch_upper_matTr_x_mat_multab     batch_upper_matTr_x_mat_multab_gf16
-#define batch_quad_trimat_eval_multab batch_quad_trimat_eval_multab_gf16
 #endif
 
 #else
@@ -75,7 +74,6 @@
 #define batch_2trimat_madd_multab   batch_2trimat_madd_multab_gf256
 #define batch_matTr_madd_multab     batch_matTr_madd_multab_gf256
 #define batch_upper_matTr_x_mat_multab     batch_upper_matTr_x_mat_multab_gf256
-#define batch_quad_trimat_eval_multab batch_quad_trimat_eval_multab_gf256
 #endif
 
 // TODO: this should be cleaner

--- a/src/parallel_matrix_op.c
+++ b/src/parallel_matrix_op.c
@@ -134,6 +134,19 @@ void batch_upper_matTr_x_mat_gf16( unsigned char *bC, const unsigned char *A_to_
 
 ////////////////////  Section: "quadratric" matrix evaluation  ///////////////////////////////
 
+#if defined(_MUL_WITH_MULTAB_)
+static void batch_quad_trimat_eval_multab_gf16( unsigned char *y, const unsigned char *trimat, const unsigned char *multabs_x, unsigned dim, unsigned size_batch );
+
+void batch_quad_trimat_eval_gf16( unsigned char *y, const unsigned char *trimat, const unsigned char *x, unsigned dim, unsigned size_batch ) {
+    #define MAX_V      (96)
+    uint8_t multabs[(MAX_V) * 32] __attribute__((aligned(32)));
+    #undef MAX_V
+    gf16v_generate_multabs( multabs, x, dim );
+    batch_quad_trimat_eval_multab_gf16( y , trimat , multabs , dim , size_batch );
+}
+
+#else
+
 void batch_quad_trimat_eval_gf16( unsigned char *y, const unsigned char *trimat, const unsigned char *x, unsigned dim, unsigned size_batch ) {
 #define MAX_O_BYTE      (64/2)
 #define MAX_V_BYTE      (96/2)
@@ -157,6 +170,8 @@ void batch_quad_trimat_eval_gf16( unsigned char *y, const unsigned char *trimat,
         trimat += (dim - i - 1) * size_batch;
     }
 }
+
+#endif
 
 
 #if defined(_MUL_WITH_MULTAB_)
@@ -288,7 +303,7 @@ void batch_upper_matTr_x_mat_multab_gf16( unsigned char *bC, const unsigned char
 }
 
 
-
+static
 void batch_quad_trimat_eval_multab_gf16( unsigned char *y, const unsigned char *trimat, const unsigned char *multab_x, unsigned dim, unsigned size_batch ) {
 ///    assert( dim <= 128 );
 ///    assert( size_batch <= 128 );
@@ -417,6 +432,19 @@ void batch_upper_matTr_x_mat_gf256( unsigned char *bC, const unsigned char *A_to
 
 ////////////////////  Section: "quadratric" matrix evaluation  ///////////////////////////////
 
+#if defined(_MUL_WITH_MULTAB_)
+static void batch_quad_trimat_eval_multab_gf256( unsigned char *y, const unsigned char *trimat, const unsigned char *multab_x, unsigned dim, unsigned size_batch );
+
+void batch_quad_trimat_eval_gf256( unsigned char *y, const unsigned char *trimat, const unsigned char *x, unsigned dim, unsigned size_batch ) {
+    #define MAX_V      (148)
+    uint8_t multabs[(MAX_V) * 32] __attribute__((aligned(32)));
+    #undef MAX_V
+    gf256v_generate_multabs( multabs, x, dim );
+    batch_quad_trimat_eval_multab_gf256( y , trimat , multabs , dim , size_batch );
+}
+
+#else
+
 void batch_quad_trimat_eval_gf256( unsigned char *y, const unsigned char *trimat, const unsigned char *x, unsigned dim, unsigned size_batch ) {
 ///
 ///    assert( dim <= 256 );
@@ -438,6 +466,7 @@ void batch_quad_trimat_eval_gf256( unsigned char *y, const unsigned char *trimat
     gf256mat_prod( tmp, trimat, size_batch, 120, quad_terms );      // 1 + 2 + ... + 15 = 120
     gf256v_add( y, tmp, size_batch );
 }
+#endif
 
 #if defined(_MUL_WITH_MULTAB_)
 
@@ -545,7 +574,7 @@ void batch_upper_matTr_x_mat_multab_gf256( unsigned char *bC, const unsigned cha
     }
 }
 
-
+static
 void batch_quad_trimat_eval_multab_gf256( unsigned char *y, const unsigned char *trimat, const unsigned char *multab_x, unsigned dim, unsigned size_batch ) {
 ///
 ///    assert( dim <= 256 );

--- a/src/parallel_matrix_op.h
+++ b/src/parallel_matrix_op.h
@@ -428,35 +428,6 @@ void batch_upper_matTr_x_mat_multab_gf256( unsigned char *bC,
 
 
 
-
-
-///
-/// @brief  y =  x^Tr * trimat * x  , in GF(16)
-///
-/// @param[out]  y          - the returned batched element y.
-/// @param[in]   trimat     - a batched matrix.
-/// @param[in]   multabs_x  - multabs of input vector x.
-/// @param[in]   dim        - the dimension of matrix trimat (and x).
-/// @param[in]   size_batch - number of the batched elements in the corresponding position of the matrix.
-///
-void batch_quad_trimat_eval_multab_gf16( unsigned char *y, const unsigned char *trimat, const unsigned char *multabs_x, unsigned dim, unsigned size_batch );
-
-///
-/// @brief  y =  x^Tr * trimat * x  , in GF(256)
-///
-/// @param[out]  y          - the returned batched element y.
-/// @param[in]   trimat     - a batched matrix.
-/// @param[in]   multabs_x  - multabs of input vector x.
-/// @param[in]   dim        - the dimension of matrix trimat (and x).
-/// @param[in]   size_batch - number of the batched elements in the corresponding position of the matrix.
-///
-void batch_quad_trimat_eval_multab_gf256( unsigned char *y, const unsigned char *trimat, const unsigned char *multabs_x, unsigned dim, unsigned size_batch );
-
-
-
-
-
-
 #ifdef  __cplusplus
 }
 #endif


### PR DESCRIPTION
I have benchmarked on neon and avx2 platforms and see no noticeable efficiency decrease for sign(). 