### PR TITLE
Add detached signature API

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -29,9 +29,19 @@ crypto_sign(unsigned char *sm, size_t *smlen,
             const unsigned char *sk);
 
 int
+crypto_sign_signature(unsigned char  *sig, size_t *siglen,
+                      const unsigned char  *m, size_t mlen,
+                      const unsigned char  *sk);
+
+int
 crypto_sign_open(unsigned char *m, size_t *mlen,
                  const unsigned char *sm, size_t smlen,
                  const unsigned char *pk);
+
+int
+crypto_sign_verify(const unsigned char  *sig, size_t siglen,
+                      const unsigned char  *m, size_t mlen,
+                      const unsigned char  *pk);
 
 #ifdef  __cplusplus
 }
@@ -39,7 +49,6 @@ crypto_sign_open(unsigned char *m, size_t *mlen,
 
 
 #elif defined(_SUPERCOP_)
-
 #include "crypto_sign.h"
 
 #else
@@ -58,9 +67,19 @@ crypto_sign(unsigned char *sm, unsigned long long *smlen,
             const unsigned char *sk);
 
 int
+crypto_sign_signature(unsigned char *sig, unsigned long long *siglen,
+                      const unsigned char *m, unsigned long long mlen,
+                      const unsigned char *sk);
+
+int
 crypto_sign_open(unsigned char *m, unsigned long long *mlen,
                  const unsigned char *sm, unsigned long long smlen,
                  const unsigned char *pk);
+
+int
+crypto_sign_verify(const unsigned char *sig, unsigned long long siglen,
+                   const unsigned char *m, unsigned long long mlen,
+                   const unsigned char *pk);
 
 #ifdef  __cplusplus
 }

--- a/unit_tests/sign_api-test.c
+++ b/unit_tests/sign_api-test.c
@@ -64,6 +64,44 @@ int main(void) {
         }
     }
     printf("all (%d,%d) tests passed.\n\n", TEST_RUN, TEST_GENKEY );
+    printf("===========  test crypto_sign_keypair(), crypto_sign_signature(), and crypto_sign_verify()  ================\n\n");
+
+    mlen = 53;
+    unsigned long long siglen;
+    unsigned char sig[CRYPTO_BYTES];
+    for (unsigned i = 0; i < TEST_RUN; i++) {
+        int rc;
+        rc = crypto_sign_keypair( pk, sk);
+        if ( 0 != rc ) {
+            printf("generating key returned %d.\n", rc);
+            ret = -1;
+            goto clean_exit;
+        }
+
+
+        for (unsigned j = 3; j < 53; j++) {
+            m[j] = (i * j) & 0xff;
+        }
+
+        rc = crypto_sign_signature( sig, &siglen, m, mlen, sk );
+
+        if ( 0 != rc ) {
+            printf("crypto_sign_signature() returned %d.\n", rc);
+            ret = -1;
+            goto clean_exit;
+        }
+
+        rc = crypto_sign_verify( sig, siglen,  m, mlen, pk );
+        if ( 0 != rc ) {
+            printf("crypto_sign_verify() return %d.\n", rc);
+            ret = -1;
+            goto clean_exit;
+        }
+
+    }
+
+    printf("all (%d) tests passed.\n\n", TEST_RUN );
+
 
 clean_exit:
     free( pk );


### PR DESCRIPTION
For liboqs integration, in addition to the standard keypair, sign, open API, additional functions creating and verifying standalone signatures are required.

This commit adds these functions and implements the existing sign and open functions on top of them.

This also resolves a bug in the previous code that would not correclty zero out the message buffer in case the signature verification fails.